### PR TITLE
Wait for flag from keeper-contracts when contracts are ready

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,9 @@
 
 export CONFIG_FILE=/provider/oceandb.ini
 envsubst < /provider/oceandb.ini.template > /provider/oceandb.ini
-sleep 30
-
+echo "Waiting for contracts to be generated..."
+while [ ! -f "/usr/local/contracts/ready" ]; do
+  sleep 2
+done
 gunicorn -b ${PROVIDER_HOST}:${PROVIDER_PORT} -w ${PROVICER_WORKERS} provider.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

Check if a flag file exists and the start loading provider. Removes sleep.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#23, oceanprotocol/keeper-contracts#105

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation