### PR TITLE
New variable to enable waiting for contracts

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,15 +2,17 @@
 
 export CONFIG_FILE=/provider/oceandb.ini
 envsubst < /provider/oceandb.ini.template > /provider/oceandb.ini
-echo "Waiting for contracts to be generated..."
-while [ ! -f "/usr/local/keeper-contracts/ready" ]; do
-  sleep 2
-done
+if [ "${LOCAL_CONTRACTS}" = "true" ]; then
+  echo "Waiting for contracts to be generated..."
+  while [ ! -f "/usr/local/keeper-contracts/ready" ]; do
+    sleep 2
+  done
+fi
 market=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanMarket.development.json', 'r'))['address'])")
 token=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanToken.development.json', 'r'))['address'])")
 auth=$(python -c "import sys, json; print(json.load(open('/usr/local/keeper-contracts/OceanAuth.development.json', 'r'))['address'])")
 sed -i -e "/token.address =/c token.address = ${token}" /provider/oceandb.ini
-sed -i -e "/market.address =/c market.address = ${market}" /provider/oceandb.ini 
+sed -i -e "/market.address =/c market.address = ${market}" /provider/oceandb.ini
 sed -i -e "/auth.address =/c auth.address = ${auth}" /provider/oceandb.ini
 gunicorn -b ${PROVIDER_HOST}:${PROVIDER_PORT} -w ${PROVICER_WORKERS} provider.run:app
 tail -f /dev/null


### PR DESCRIPTION
## Description

Included the variable `$LOCAL_CONTRACTS`. If it is equal to "true", it will wait for the file `/usr/local/keeper-contracts/ready` to exists before starting. In other case it will start directly.

## Is this PR related with an open issue?

Related to Issue oceanprotocol/docker-images#25

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()