### PR TITLE
run CI tests against default barge versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,11 +18,7 @@ jobs:
         name: Checkout Barge
         with:
           repository: "oceanprotocol/barge"
-          ref: 'v3'
           path: 'barge'
-        env:
-          AQUARIUS_VERSION: 'v3'
-          CONTRACTS_VERSION: latest
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |


### PR DESCRIPTION
Some finding while setting this up over on `market`. Relying on the `v3` branch in barge, and specific versions of Aquarius & contracts is not future-proof. Additionally, the set env vars were never active cause they should be set on the `Run Barge` step. Regardless, I removed them all so testing always happens against latest release versions of everything instead of old branches/versions

Test run now might fail, cause there's this issue I discovered where latest `contracts` builds are not on DockerHub, which probably was the reason to set specific versions https://github.com/oceanprotocol/contracts/issues/265. As soon as hat's available, restarting test runs should make them green