### PR TITLE
Disable modification tracking and catch table already exists error.

### DIFF
--- a/ocean_provider/myapp.py
+++ b/ocean_provider/myapp.py
@@ -2,12 +2,13 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import os
+import sqlite3
 from os.path import abspath, dirname
 
 from flask import Flask
 from flask_cors import CORS
 from flask_sieve import Sieve
-
+from ocean_provider.models import db as db_models  # noqa isort: skip
 from ocean_provider.utils.basics import get_config
 
 app = Flask(__name__)
@@ -19,13 +20,17 @@ if "CONFIG_FILE" in os.environ and os.environ["CONFIG_FILE"]:
 else:
     app.config["CONFIG_FILE"] = "config.ini"
 
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 PROJECT_ROOT = dirname(dirname(abspath(__file__)))
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:////" + os.path.join(
     PROJECT_ROOT, "db", get_config().storage_path
 )
 
-from ocean_provider.models import db as db_models  # noqa isort: skip
 
 db = db_models
-db.create_all()
+
+try:
+    db.create_all()
+except sqlite3.OperationalError:
+    pass

--- a/ocean_provider/myapp.py
+++ b/ocean_provider/myapp.py
@@ -8,7 +8,6 @@ from os.path import abspath, dirname
 from flask import Flask
 from flask_cors import CORS
 from flask_sieve import Sieve
-from ocean_provider.models import db as db_models  # noqa isort: skip
 from ocean_provider.utils.basics import get_config
 
 app = Flask(__name__)
@@ -27,7 +26,7 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:////" + os.path.join(
     PROJECT_ROOT, "db", get_config().storage_path
 )
 
-
+from ocean_provider.models import db as db_models  # noqa isort: skip
 db = db_models
 
 try:

--- a/ocean_provider/myapp.py
+++ b/ocean_provider/myapp.py
@@ -4,7 +4,6 @@
 import os
 import sqlite3
 from os.path import abspath, dirname
-
 from flask import Flask
 from flask_cors import CORS
 from flask_sieve import Sieve


### PR DESCRIPTION
Fixes #101.

Changes proposed in this PR:

- disable SQLALCHEMY_TRACK_MODIFICATIONS for cleaner logs in Barge
- add exception handling on table already exists (fail gracefully)
- no unit test since it can only be reproduced by running in barge. I tried running the app locally in 2 different tabs and both worked fine, even before the fix.