### PR TITLE
Remove references to master branch in bumpversion.sh.

### DIFF
--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -29,10 +29,10 @@ elif [[ $1 != 'major' && $1 != 'minor' && $1 != 'patch' ]]; then
 fi
 
 if [[ $2 == '--tag' ]]; then
-  if git branch --contains $(git rev-parse --verify HEAD) | grep -E 'master'; then
+  if git branch --contains $(git rev-parse --verify HEAD) | grep -E 'main'; then
     bumpversion --tag --commit $1
   else
-    echo "Only master tags can be tagged"
+    echo "Only main tags can be tagged"
     exit 1
   fi
 else


### PR DESCRIPTION
Fixes #104.

Changes proposed in this PR:

- Remove references to master branch in code (only found in the bumpversion script).