### PR TITLE
Refactored the credentials part from RBAC server logic

### DIFF
--- a/ocean_provider/validation/RBAC.py
+++ b/ocean_provider/validation/RBAC.py
@@ -12,7 +12,6 @@ from ocean_lib.common.agreements.service_types import ServiceTypesIndices
 from ocean_provider.exceptions import RequestNotFound
 from ocean_provider.utils.accounts import sign_message
 from ocean_provider.utils.basics import get_provider_wallet
-from ocean_provider.utils.util import msg_hash
 
 
 class RBACValidator:
@@ -27,10 +26,12 @@ class RBACValidator:
             raise RequestNotFound("Request name is not valid!")
         self.action = action_mapping[request_name]
         self.provider_address = get_provider_wallet().address
-        self.credentials = {
-            "type": "address",
-            "address": self.provider_address,
-        }
+        address = (
+            self.request["consumerAddress"]
+            if "consumerAddress" in self.request and self.request["consumerAddress"]
+            else self.request["publisherAddress"]
+        )
+        self.credentials = {"type": "address", "address": address}
         self.component = "provider"
 
     @staticmethod

--- a/ocean_provider/validation/RBAC.py
+++ b/ocean_provider/validation/RBAC.py
@@ -26,10 +26,8 @@ class RBACValidator:
             raise RequestNotFound("Request name is not valid!")
         self.action = action_mapping[request_name]
         self.provider_address = get_provider_wallet().address
-        address = (
-            self.request["consumerAddress"]
-            if "consumerAddress" in self.request and self.request["consumerAddress"]
-            else self.request["publisherAddress"]
+        address = self.request.get(
+            "consumerAddress", self.request.get("publisherAddress")
         )
         self.credentials = {"type": "address", "address": address}
         self.component = "provider"

--- a/tests/test_RBAC.py
+++ b/tests/test_RBAC.py
@@ -31,7 +31,7 @@ def test_invalid_request_name():
 encrypt_endpoint = BaseURLs.ASSETS_URL + "/encrypt"
 
 
-def test_encrypt_request_payload(provider_address):
+def test_encrypt_request_payload(consumer_wallet, publisher_wallet):
     document = {
         "url": "http://localhost:8030" + encrypt_endpoint,
         "index": 0,
@@ -41,7 +41,10 @@ def test_encrypt_request_payload(provider_address):
         "encoding": "UTF-8",
         "compression": "zip",
     }
-    req = {"document": json.dumps(document)}
+    req = {
+        "document": json.dumps(document),
+        "publisherAddress": publisher_wallet.address,
+    }
     validator = RBACValidator(request_name="EncryptRequest", request=req)
     payload = validator.build_payload()
     assert validator.request == req
@@ -49,7 +52,7 @@ def test_encrypt_request_payload(provider_address):
     assert payload["component"] == "provider"
     assert payload["credentials"] == {
         "type": "address",
-        "address": provider_address,
+        "address": publisher_wallet.address,
     }
 
 
@@ -76,7 +79,7 @@ def test_initialize_request_payload(
     assert payload["component"] == "provider"
     assert payload["credentials"] == {
         "type": "address",
-        "address": provider_address,
+        "address": consumer_wallet.address,
     }
     assert payload["dids"][0]["did"] == ddo.did
     assert payload["dids"][0]["serviceId"] == sa.index
@@ -111,7 +114,7 @@ def test_access_request_payload(
     assert payload["component"] == "provider"
     assert payload["credentials"] == {
         "type": "address",
-        "address": provider_address,
+        "address": consumer_wallet.address,
     }
     assert payload["dids"][0]["did"] == ddo.did
     assert payload["dids"][0]["serviceId"] == sa.index
@@ -150,7 +153,7 @@ def test_compute_payload_without_additional_inputs(
     assert payload["component"] == "provider"
     assert payload["credentials"] == {
         "type": "address",
-        "address": provider_address,
+        "address": consumer_wallet.address,
     }
     assert payload["dids"][0]["did"] == dataset.did
     assert payload["dids"][0]["serviceId"] == sa.index
@@ -198,7 +201,7 @@ def test_compute_request_payload(
     assert payload["component"] == "provider"
     assert payload["credentials"] == {
         "type": "address",
-        "address": provider_address,
+        "address": consumer_wallet.address,
     }
     assert payload["dids"][0]["did"] == dataset.did
     assert payload["dids"][0]["serviceId"] == sa.index


### PR DESCRIPTION

Fixes #186  .

Changes proposed in this PR:

- replace `provider_address` from credentials with the request's consumer address;
- refactor RBAC unit tests;
- remove unused imports.