### PR TITLE
Bump version: 0.4.12 → 0.4.13

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.12
+current_version = 0.4.13
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     url="https://github.com/oceanprotocol/provider-py",
     # fmt: off
     # bumpversion needs single quotes
-    version='0.4.12',
+    version='0.4.13',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Release for: recover signed messages and fix some ocean.py version issues.