### PR TITLE
Fix crash when signature is not sent on ComputeResult.

### DIFF
--- a/ocean_provider/validation/provider_requests.py
+++ b/ocean_provider/validation/provider_requests.py
@@ -187,7 +187,7 @@ class ComputeGetResult(CustomJsonRequest):
             "jobId": ["bail", "required"],
             "index": ["bail", "required"],
             "consumerAddress": ["bail", "required"],
-            "signature": ["required", "signature:consumerAddress,index,jobId"],
+            "signature": ["bail", "required", "signature:consumerAddress,index,jobId"],
         }
 
 

--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -145,12 +145,16 @@ def get_compute_job_info(client, endpoint, params):
     return dict(job_info[0])
 
 
-def get_compute_result(client, endpoint, params):
+def get_compute_result(client, endpoint, params, raw_response=False):
     # not possible to use PrepparedRequest here,
     # since we don't have the full url (schema, host) in the tests
     response = client.get(
         endpoint + "?" + "&".join([f"{k}={v}" for k, v in params.items()])
     )
+
+    if raw_response:
+        return response
+
     assert (
         response.status_code == 200
     ), f"get compute result failed: status {response.status}, data {response.data}"

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -199,15 +199,23 @@ def test_compute(client, publisher_wallet, consumer_wallet):
 
     assert tries <= 200, "Timeout waiting for the job to be completed"
     index = 0
-    signature = get_compute_signature(client, consumer_wallet, index, job_id)
-    payload = dict(
-        {
-            "signature": signature,
-            "index": index,
-            "consumerAddress": consumer_wallet.address,
-            "jobId": job_id,
-        }
+    payload = {
+        "index": index,
+        "consumerAddress": consumer_wallet.address,
+        "jobId": job_id,
+    }
+
+    result_without_signature = get_compute_result(
+        client, BaseURLs.ASSETS_URL + "/computeResult", payload, raw_response=True
     )
+    assert result_without_signature.status_code == 400
+    assert (
+        result_without_signature.json["errors"]["signature"][0]
+        == "The signature field is required."
+    ), "Signature should be required"
+
+    signature = get_compute_signature(client, consumer_wallet, index, job_id)
+    payload["signature"] = signature
     result_data = get_compute_result(
         client, BaseURLs.ASSETS_URL + "/computeResult", payload
     )


### PR DESCRIPTION
Closes #204.

@alexcos20 I fixed the crash by bailing if the signature is not sent, but I see that #203 proposes an unsigned version of this endpoint. Can you advise? Should I work on a version where the signature is not required?