### PR TITLE
fix unsigned get compute result  (pass results)

### DIFF
--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -244,8 +244,6 @@ def computeStatus():
                 "resultsUrl",
                 "algorithmLogUrl",
                 "resultsDid",
-                "results",
-                "owner",
             ]
             for job_info in resp_content:
                 for k in keys_to_filter:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -162,7 +162,6 @@ def test_compute(client, publisher_wallet, consumer_wallet):
     payload.pop("signature")
     job_info = get_compute_job_info(client, compute_endpoint, payload)
     assert job_info, f"Failed to get job status without signature: payload={payload}"
-    assert "owner" not in job_info, "owner should not be in this status response"
     assert (
         "resultsUrl" not in job_info
     ), "resultsUrl should not be in this status response"

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -176,7 +176,6 @@ def test_compute(client, publisher_wallet, consumer_wallet):
     payload["signature"] = ""
     job_info = get_compute_job_info(client, compute_endpoint, payload)
     assert job_info, f"Failed to get job status without signature: payload={payload}"
-    assert "owner" not in job_info, "owner should not be in this status response"
     assert (
         "resultsUrl" not in job_info
     ), "resultsUrl should not be in this status response"


### PR DESCRIPTION
Closes #203 


Changes proposed in this PR:

GET /compute should:
1. filter old format fields ("resultsUrl",   "algorithmLogUrl",  "resultsDid").  This fields are still available with a signature (backwards compat)
2. should not filter results fields, because that is public
