### PR TITLE
Fix decrypt endpoint request validation

### DIFF
--- a/ocean_provider/validation/provider_requests.py
+++ b/ocean_provider/validation/provider_requests.py
@@ -194,17 +194,15 @@ class DecryptRequest(CustomJsonRequest):
                 "required_without:transactionId",
                 "required_with:flags,documentHash",
             ],
-            # TODO Adapt flags validation to accept "\x00"
-            # "flags": [
-            #     "required_without:transactionId",
-            #     "required_with:encryptedDocument,documentHash",
-            # ],
+            "flags": [
+                "required_without:transactionId",
+                "required_with:encryptedDocument,documentHash",
+            ],
             "documentHash": [
                 "required_without:transactionId",
                 "required_with:encryptedDocument,flags",
             ],
-            # TODO: put this back. This also fails when sending 0
-            # "nonce": ["required"],
+            "nonce": ["required"],
             "signature": [
                 "bail",
                 "required",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requirements = [
     "coincurve>=13,<15",
     "ipaddress",
     "dnspython",
-    "flask-sieve==1.2.2",
+    "flask-sieve==1.3.1",
     "SQLAlchemy==1.3.23",
     "json-sempai==0.4.0",
 ]

--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -5,7 +5,7 @@ import uuid
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.accounts import sign_message
 from ocean_provider.utils.datatoken import get_dt_contract
-from tests.helpers.service_definitions import (
+from tests.helpers.ddo_dict_builders import (
     get_compute_service,
     get_compute_service_allow_all_published,
     get_compute_service_no_rawalgo,


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #236 .

Changes proposed in this PR:

- Update flask-sieve version to `v1.3.1` to fix the documented problem : `0` and `false` values were making the rule required fail . See: https://github.com/codingedward/flask-sieve/releases/tag/v1.3.1
- Replaced non-existing module `tests.helpers.service_definitions` with `tests.helpers.ddo_dict_builders`
- Prior to this update, some tests were already failing. The flask-sieve version upgrade doesn't seem to introduce new problems:

  Tests run with `flask-sieve==1.2.2` **without flags and nonce validation rules**: 28 Failed, 37 Passed, 69 Warnings
  ![Screenshot from 2021-11-15 12-34-33](https://user-images.githubusercontent.com/53186719/141783091-78cd91b1-bba7-4da7-bb03-6d13eb7bfef0.png)
  
  Tests run with `flask-sieve==1.3.1` [**with flags and nonce validation rules**](https://github.com/oceanprotocol/provider/blob/290f6f17d2f20ec04e0524c066ea1a398683cbd8/ocean_provider/validation/provider_requests.py#L197) : 28 Failed, 37 Passed, 69 Warnings
  ![Screenshot from 2021-11-15 12-30-08](https://user-images.githubusercontent.com/53186719/141783389-37964d1e-948e-4a3c-aa96-16b71fa66ad6.png)
   
   Compare errors before vs after: No differences
  ![image](https://user-images.githubusercontent.com/53186719/141785070-48e6466c-6f78-4471-8e7c-3ebbd65dd1c2.png)
