### PR TITLE
Issue246 ganache chain id 8996

### DIFF
--- a/ocean_provider/utils/address.py
+++ b/ocean_provider/utils/address.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+from pathlib import Path
+from typing import Any, Dict, Union
+
+from eth_typing.evm import HexAddress
+
+
+def get_address_json(address_path: Union[str, Path]) -> Dict[str, Any]:
+    """Return the json object of all Ocean contract addresses on all chains."""
+    if isinstance(address_path, str):
+        address_path = Path(address_path)
+    address_file = address_path.expanduser().resolve()
+    with open(address_file) as f:
+        return json.load(f)
+
+
+def get_contract_address(
+    address_path: str, contract_name: str, chain_id: int
+) -> HexAddress:
+    """Return the contract address with the given name and chain id"""
+    address_json = get_address_json(address_path)
+    return next(
+        chain_addresses[contract_name]
+        for chain_addresses in address_json.values()
+        if chain_addresses["chainId"] == chain_id
+    )

--- a/ocean_provider/utils/data_nft_factory.py
+++ b/ocean_provider/utils/data_nft_factory.py
@@ -2,30 +2,19 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-import json
-from pathlib import Path
-
 from jsonsempai import magic  # noqa: F401
 from artifacts import ERC721Factory
+from ocean_provider.utils.address import get_contract_address
 from ocean_provider.utils.basics import get_config
 from web3.contract import Contract
 from web3.logs import DISCARD
 from web3.main import Web3
 
-CHAIN_ID_TO_NETWORK_NAME = {1337: "development"}
-
 
 def get_data_nft_factory_address(web3: Web3) -> str:
-    address_file = Path(get_config().address_file).expanduser().resolve()
-    with open(address_file) as f:
-        address_json = json.load(f)
-
-    chain_id = web3.eth.chain_id
-    network_name = CHAIN_ID_TO_NETWORK_NAME.get(chain_id)
-    if not network_name:
-        raise ValueError(f"Unsupported chain id: {chain_id}")
-
-    return address_json[network_name]["ERC721Factory"]
+    return get_contract_address(
+        get_config().address_file, "ERC721Factory", web3.eth.chain_id
+    )
 
 
 def get_data_nft_factory_contract(web3: Web3) -> Contract:

--- a/ocean_provider/utils/test/test_address.py
+++ b/ocean_provider/utils/test/test_address.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from ocean_provider.utils.address import get_address_json, get_contract_address
+from ocean_provider.utils.basics import get_config
+
+
+def test_get_address_json():
+    address_json = get_address_json(get_config().address_file)
+    assert address_json["development"]["chainId"] == 8996
+    assert address_json["development"]["Ocean"].startswith("0x")
+
+
+def test_get_contract_address():
+    assert get_contract_address(
+        get_config().address_file, "ERC721Factory", 8996
+    ).startswith("0x")

--- a/tests/ddo/ddo_event_sample_v4.py
+++ b/tests/ddo/ddo_event_sample_v4.py
@@ -8,7 +8,7 @@ ddo_event_sample_v4 = {
     "created": "2000-10-31T01:30:00.000-05:00",
     "updated": "2000-10-31T01:30:00.000-05:00",
     "version": "4.0.0",
-    "chainId": 1337,
+    "chainId": 8996,
     "metadata": {
         "type": "dataset",
         "name": "Event DDO sample",

--- a/tests/ddo/ddo_sample1_v4.py
+++ b/tests/ddo/ddo_sample1_v4.py
@@ -6,7 +6,7 @@ json_dict = {
     "@context": ["https://w3id.org/did/v1"],
     "id": "did:op:0c184915b07b44c888d468be85a9b28253e80070e5294b1aaed81c2f0264e430",
     "version": "4.0.0",
-    "chainId": 1337,
+    "chainId": 8996,
     "metadata": {
         "created": "2000-10-31T01:30:00.000-05:00",
         "updated": "2000-10-31T01:30:00.000-05:00",

--- a/tests/ddo/ddo_sample_algorithm_v4.py
+++ b/tests/ddo/ddo_sample_algorithm_v4.py
@@ -6,7 +6,7 @@ algorithm_ddo_sample = {
     "@context": ["https://w3id.org/did/v1"],
     "id": "did:op:0bc278fee025464f8012b811d1bce8e22094d0984e4e49139df5d5ff7a028bdf",
     "version": "4.0.0",
-    "chainId": 1337,
+    "chainId": 8996,
     "proof": {
         "created": "2019-02-08T08:13:41Z",
         "creator": "0x37BB53e3d293494DE59fBe1FF78500423dcFd43B",

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -59,7 +59,7 @@ def test_decrypt_with_plain_input(
     )
 
     # Set common decrypt arguments
-    chain_id = 1337
+    chain_id = web3.eth.chain_id
 
     # Decrypt DDO using transactionId
     decrypt_response = decrypt_ddo_using_transaction_id(
@@ -130,7 +130,7 @@ def test_decrypt_with_compressed_input(
     )
 
     # Set common decrypt arguments
-    chain_id = 1337
+    chain_id = web3.eth.chain_id
 
     # Decrypt DDO using transactionId
     decrypt_response = decrypt_ddo_using_transaction_id(
@@ -211,7 +211,7 @@ def test_encrypt_and_decrypt_with_only_encryption(
     )
 
     # Set common decrypt arguments
-    chain_id = 1337
+    chain_id = web3.eth.chain_id
 
     # Decrypt DDO using transactionId
     decrypt_response = decrypt_ddo_using_transaction_id(
@@ -294,7 +294,7 @@ def test_encrypt_and_decrypt_with_compression_and_encryption(
     )
 
     # Set common decrypt arguments
-    chain_id = 1337
+    chain_id = web3.eth.chain_id
 
     # Decrypt DDO using transactionId
     decrypt_response = decrypt_ddo_using_transaction_id(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,6 +16,7 @@ from eth_typing.encoding import HexStr
 from eth_typing.evm import HexAddress
 from flask.testing import FlaskClient
 from ocean_provider.constants import BaseURLs
+from ocean_provider.utils.address import get_contract_address
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
     get_config,
@@ -23,10 +24,7 @@ from ocean_provider.utils.basics import (
 )
 from ocean_provider.utils.currency import to_wei
 from ocean_provider.utils.data_nft import Flags, MetadataState, get_data_nft_contract
-from ocean_provider.utils.data_nft_factory import (
-    CHAIN_ID_TO_NETWORK_NAME,
-    get_data_nft_factory_contract,
-)
+from ocean_provider.utils.data_nft_factory import get_data_nft_factory_contract
 from ocean_provider.utils.datatoken import get_datatoken_contract
 from ocean_provider.utils.did import compute_did_from_data_nft_address_and_chain_id
 from tests.ddo.ddo_sample1_v4 import json_dict as ddo_sample1_v4
@@ -84,16 +82,7 @@ def deploy_contract(w3, _json, private_key, *args):
 
 
 def get_ocean_token_address(web3: Web3) -> HexAddress:
-    address_file = pathlib.Path(get_config().address_file).expanduser().resolve()
-    with open(address_file) as f:
-        address_json = json.load(f)
-
-    chain_id = web3.eth.chain_id
-    network_name = CHAIN_ID_TO_NETWORK_NAME.get(chain_id)
-    if not network_name:
-        raise ValueError(f"Unsupported chain id: {chain_id}")
-
-    return address_json[network_name]["Ocean"]
+    return get_contract_address(get_config().address_file, "Ocean", web3.eth.chain_id)
 
 
 def sign_send_and_wait_for_receipt(


### PR DESCRIPTION
Closes #246 

# Changes proposed in this PR:

- Remove all the places `1337` is used as the chain_id.
- Replace hardcoded `chain_id`s with `web3.eth.chain_id` wherever possible
- Add `get_address_json` and `get_contract_address` utils
- Add `test_get_address_json` and `test_get_contract_address` unit tests
- Remove `CHAIN_ID_TO_NETWORK_NAME` map. Use new address utils instead.

# Test Status
The newly added unit tests are passing, but many of the other unit tests are still in a broken state.

```
ocean_provider/utils/test/test_address.py ..                             [ 16%]
```