### PR TITLE
Fix todos in download endpoint

### DIFF
--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -7,7 +7,6 @@ import logging
 
 from flask import Response, jsonify, request
 from flask_sieve import validate
-
 from ocean_provider.log import setup_logging
 from ocean_provider.myapp import app
 from ocean_provider.requests_session import get_requests_session
@@ -247,12 +246,7 @@ def download():
             get_web3(), consumer_address, token_address, 1, tx_id, did, service
         )
 
-        # TODO: validate transfer not used for other service?
-
         file_index = int(data.get("fileIndex"))
-
-        # TODO: get content type
-        content_type = None
 
         url = get_service_files_list(service, provider_wallet)[file_index]
         if not url:
@@ -265,6 +259,9 @@ def download():
 
         download_url = get_download_url(url, app.config["PROVIDER_CONFIG_FILE"])
         download_url = append_userdata(download_url, data)
+
+        valid, details = check_url_details(url)
+        content_type = details["contentType"] if valid else None
 
         logger.info(
             f"Done processing consume request for asset {did}, " f" url {download_url}"

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -1,16 +1,15 @@
 from typing import Optional
 
+from jsonsempai import magic  # noqa: F401
+from artifacts import ERC20Template
 from eth_typing.encoding import HexStr
 from eth_typing.evm import HexAddress
 from hexbytes import HexBytes
-from jsonsempai import magic  # noqa: F401
+from ocean_provider.utils.services import Service
 from web3.contract import Contract
 from web3.logs import DISCARD
 from web3.main import Web3
 from websockets import ConnectionClosed
-
-from artifacts import ERC20Template
-from ocean_provider.utils.services import Service
 
 
 def get_datatoken_contract(web3: Web3, address: Optional[str] = None) -> Contract:
@@ -59,9 +58,10 @@ def verify_order_tx(
         raise AssertionError(
             f"Cannot find the event for the order transaction with tx id {tx_id}."
         )
-    assert (
-        len(event_logs) == 1
-    ), f"Multiple order events in the same transaction !!! {event_logs}"
+    if len(event_logs) > 1:
+        raise AssertionError(
+            f"Multiple order events in the same transaction !!! {event_logs}"
+        )
 
     if order_log.args.serviceIndex != service.index:
         raise AssertionError(


### PR DESCRIPTION
Changes proposed in this PR:

- Fixes the remaining TODOs in the `download` endpoint.
  - Populate the `contentType` attribute in the `Response`
  - Remove TODO related to service validation. `validate_order` already validates that the `serviceIndex` provided by the caller matches the `serviceIndex` in the `OrderStarted` event. 
- Replaced an `assert` statement with an `if + exception` in production code.
- Minor formatting changes from pre-commit checks (black, isort, and flake)