### PR TITLE
Issue287 prevent leaking infura project id

### DIFF
--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -7,21 +7,19 @@ import logging
 
 from flask import Response, jsonify, request
 from flask_sieve import validate
-from requests.models import PreparedRequest
-
 from ocean_provider.exceptions import InvalidSignatureError
 from ocean_provider.log import setup_logging
 from ocean_provider.requests_session import get_requests_session
 from ocean_provider.user_nonce import get_nonce, increment_nonce
 from ocean_provider.utils.accounts import sign_message, verify_signature
 from ocean_provider.utils.basics import LocalFileAdapter, get_provider_wallet, get_web3
+from ocean_provider.utils.error_responses import service_unavailable
 from ocean_provider.utils.util import (
     build_download_response,
     get_compute_endpoint,
     get_compute_result_endpoint,
     get_request_data,
     process_compute_request,
-    service_unavailable,
 )
 from ocean_provider.validation.algo import WorkflowValidator
 from ocean_provider.validation.provider_requests import (
@@ -30,6 +28,7 @@ from ocean_provider.validation.provider_requests import (
     ComputeStartRequest,
     UnsignedComputeRequest,
 )
+from requests.models import PreparedRequest
 
 from . import services
 
@@ -87,15 +86,11 @@ def computeDelete():
     try:
         body = process_compute_request(data)
         response = requests_session.delete(
-            get_compute_endpoint(),
-            params=body,
-            headers=standard_headers,
+            get_compute_endpoint(), params=body, headers=standard_headers
         )
         increment_nonce(body["owner"])
         return Response(
-            response.content,
-            response.status_code,
-            headers=standard_headers,
+            response.content, response.status_code, headers=standard_headers
         )
     except (ValueError, Exception) as e:
         return service_unavailable(e, data, logger)
@@ -149,15 +144,11 @@ def computeStop():
     try:
         body = process_compute_request(data)
         response = requests_session.put(
-            get_compute_endpoint(),
-            params=body,
-            headers=standard_headers,
+            get_compute_endpoint(), params=body, headers=standard_headers
         )
         increment_nonce(body["owner"])
         return Response(
-            response.content,
-            response.status_code,
-            headers=standard_headers,
+            response.content, response.status_code, headers=standard_headers
         )
     except (ValueError, Exception) as e:
         return service_unavailable(e, data, logger)
@@ -213,9 +204,7 @@ def computeStatus():
         body = process_compute_request(data)
 
         response = requests_session.get(
-            get_compute_endpoint(),
-            params=body,
-            headers=standard_headers,
+            get_compute_endpoint(), params=body, headers=standard_headers
         )
 
         _response = response.content
@@ -241,11 +230,7 @@ def computeStatus():
             if not isinstance(resp_content, list):
                 resp_content = [resp_content]
             _response = []
-            keys_to_filter = [
-                "resultsUrl",
-                "algorithmLogUrl",
-                "resultsDid",
-            ]
+            keys_to_filter = ["resultsUrl", "algorithmLogUrl", "resultsDid"]
             for job_info in resp_content:
                 for k in keys_to_filter:
                     job_info.pop(k, None)
@@ -253,11 +238,7 @@ def computeStatus():
 
             _response = json.dumps(_response)
 
-        return Response(
-            _response,
-            response.status_code,
-            headers=standard_headers,
-        )
+        return Response(_response, response.status_code, headers=standard_headers)
 
     except (ValueError, Exception) as e:
         return service_unavailable(e, data, logger)
@@ -342,15 +323,11 @@ def computeStart():
             "providerAddress": provider_wallet.address,
         }
         response = requests_session.post(
-            get_compute_endpoint(),
-            data=json.dumps(payload),
-            headers=standard_headers,
+            get_compute_endpoint(), data=json.dumps(payload), headers=standard_headers
         )
         increment_nonce(consumer_address)
         return Response(
-            response.content,
-            response.status_code,
-            headers=standard_headers,
+            response.content, response.status_code, headers=standard_headers
         )
     except (ValueError, KeyError, Exception) as e:
         return service_unavailable(e, data, logger)

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -8,7 +8,6 @@ import logging
 from eth_utils import add_0x_prefix
 from flask import Response, jsonify, request
 from flask_sieve import validate
-
 from ocean_provider.log import setup_logging
 from ocean_provider.myapp import app
 from ocean_provider.requests_session import get_requests_session
@@ -22,6 +21,7 @@ from ocean_provider.utils.basics import (
 )
 from ocean_provider.utils.did import did_to_id
 from ocean_provider.utils.encryption import do_encrypt
+from ocean_provider.utils.error_responses import service_unavailable
 from ocean_provider.utils.url import append_userdata, check_url_details
 from ocean_provider.utils.util import (
     build_download_response,
@@ -34,7 +34,6 @@ from ocean_provider.utils.util import (
     get_request_data,
     process_consume_request,
     record_consume_request,
-    service_unavailable,
     validate_order,
     validate_transfer_not_used_for_other_service,
 )

--- a/ocean_provider/utils/error_responses.py
+++ b/ocean_provider/utils/error_responses.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+import logging
+import re
+
+from flask.wrappers import Response
+
+logger = logging.getLogger(__name__)
+
+INFURA_ENDPOINT_HTTPS = ".infura.io/v3/"
+INFURA_ENDPOINT_WSS = ".infura.io/ws/v3/"
+STRIPPED_INFURA_ID_MSG = "<infura project id stripped for security reasons>"
+
+
+def service_unavailable(error, context, custom_logger=None):
+    error = strip_infura_project_id(str(error))
+
+    text_items = []
+    for key, value in context.items():
+        value = value if isinstance(value, str) else json.dumps(value)
+        text_items.append(key + "=" + value)
+
+    logger_message = "Payload was: " + ",".join(text_items)
+    custom_logger = custom_logger if custom_logger else logger
+    custom_logger.error(f"error = {error}, input data = {logger_message}", exc_info=1)
+
+    return Response(
+        json.dumps({"error": str(error), "context": context}),
+        503,
+        headers={"content-type": "application/json"},
+    )
+
+
+def strip_infura_project_id(error: str) -> str:
+    if INFURA_ENDPOINT_HTTPS in error:
+        error = re.sub(
+            rf"{INFURA_ENDPOINT_HTTPS}\S+",
+            f"{INFURA_ENDPOINT_HTTPS}{STRIPPED_INFURA_ID_MSG}",
+            error,
+        )
+    if INFURA_ENDPOINT_WSS in error:
+        error = re.sub(
+            rf"{INFURA_ENDPOINT_WSS}\S+",
+            f"{INFURA_ENDPOINT_WSS}{STRIPPED_INFURA_ID_MSG}",
+            error,
+        )
+    return error

--- a/ocean_provider/utils/error_responses.py
+++ b/ocean_provider/utils/error_responses.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 INFURA_ENDPOINT_HTTPS = ".infura.io/v3/"
 INFURA_ENDPOINT_WSS = ".infura.io/ws/v3/"
-STRIPPED_INFURA_ID_MSG = "<infura project id stripped for security reasons>"
+STRIPPED_INFURA_PROJECT_ID_MSG = "<infura project id stripped for security reasons>"
 
 
 def service_unavailable(error, context, custom_logger=None):
@@ -38,13 +38,13 @@ def strip_infura_project_id(error: str) -> str:
     if INFURA_ENDPOINT_HTTPS in error:
         error = re.sub(
             rf"{INFURA_ENDPOINT_HTTPS}\S+",
-            f"{INFURA_ENDPOINT_HTTPS}{STRIPPED_INFURA_ID_MSG}",
+            f"{INFURA_ENDPOINT_HTTPS}{STRIPPED_INFURA_PROJECT_ID_MSG}",
             error,
         )
     if INFURA_ENDPOINT_WSS in error:
         error = re.sub(
             rf"{INFURA_ENDPOINT_WSS}\S+",
-            f"{INFURA_ENDPOINT_WSS}{STRIPPED_INFURA_ID_MSG}",
+            f"{INFURA_ENDPOINT_WSS}{STRIPPED_INFURA_PROJECT_ID_MSG}",
             error,
         )
     return error

--- a/ocean_provider/utils/error_responses.py
+++ b/ocean_provider/utils/error_responses.py
@@ -23,9 +23,9 @@ def service_unavailable(error, context, custom_logger=None):
         value = value if isinstance(value, str) else json.dumps(value)
         text_items.append(key + "=" + value)
 
-    logger_message = "Payload was: " + ",".join(text_items)
+    logger_message = ",".join(text_items)
     custom_logger = custom_logger if custom_logger else logger
-    custom_logger.error(f"error = {error}, input data = {logger_message}", exc_info=1)
+    custom_logger.error(f"error: {error}, payload: {logger_message}", exc_info=1)
 
     return Response(
         json.dumps({"error": str(error), "context": context}),

--- a/ocean_provider/utils/test/test_error_responses.py
+++ b/ocean_provider/utils/test/test_error_responses.py
@@ -17,7 +17,9 @@ def test_service_unavailable(caplog):
     response = response.json
     assert response["error"] == "test message"
     assert response["context"] == context
-    assert caplog.records[0].msg == "Payload was: item1=test1,item2=test2"
+    assert (
+        caplog.records[0].msg == "error: test message, payload: item1=test1,item2=test2"
+    )
 
 
 def test_service_unavailable_strip_infura_project_id():

--- a/ocean_provider/utils/test/test_error_responses.py
+++ b/ocean_provider/utils/test/test_error_responses.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import logging
+
+from ocean_provider.utils.error_responses import service_unavailable
+
+test_logger = logging.getLogger(__name__)
+
+
+def test_service_unavailable(caplog):
+    e = Exception("test message")
+    context = {"item1": "test1", "item2": "test2"}
+    response = service_unavailable(e, context, test_logger)
+    assert response.status_code == 503
+    response = response.json
+    assert response["error"] == "test message"
+    assert response["context"] == context
+    assert caplog.records[0].msg == "Payload was: item1=test1,item2=test2"
+
+
+def test_service_unavailable_strip_infura_project_id():
+    """Test that service_unavilable strips out infura project IDs."""
+
+    context = {"item1": "test1", "item2": "test2"}
+
+    # HTTP Infura URL (rinkeby)
+    e = Exception(
+        "429 Client Error: Too Many Requests for url: "
+        "https://rinkeby.infura.io/v3/ffffffffffffffffffffffffffffffff"
+    )
+    response = service_unavailable(e, context, test_logger)
+    assert (
+        response.json["error"] == "429 Client Error: Too Many Requests for url: "
+        "https://rinkeby.infura.io/v3/<infura project id stripped for security reasons>"
+    )
+
+    # Websocket Infura URL (ropsten)
+    e = Exception(
+        "429 Client Error: Too Many Requests for url: "
+        "https://ropsten.infura.io/ws/v3/ffffffffffffffffffffffffffffffff"
+    )
+    response = service_unavailable(e, context, test_logger)
+    assert (
+        response.json["error"] == "429 Client Error: Too Many Requests for url: "
+        "https://ropsten.infura.io/ws/v3/<infura project id stripped for security reasons>"
+    )
+
+    # Other
+    e = Exception("anything .infura.io/v3/<any_non_whitespace_string>")
+    response = service_unavailable(e, context, test_logger)
+    assert (
+        response.json["error"]
+        == "anything .infura.io/v3/<infura project id stripped for security reasons>"
+    )

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -45,7 +45,7 @@ def test_service_unavailable(caplog):
     assert caplog.records[0].msg == "Payload was: item1=test1,item2=test2"
 
 
-def test_service_unavailable_strip_infura_key():
+def test_service_unavailable_strip_infura_project_id():
     """Test that service_unavilable strips out infura project IDs."""
 
     context = {"item1": "test1", "item2": "test2"}

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -20,7 +20,6 @@ from ocean_provider.utils.util import (
     get_asset_urls,
     get_download_url,
     msg_hash,
-    service_unavailable,
 )
 from werkzeug.utils import get_content_type
 
@@ -32,53 +31,6 @@ def test_msg_hash():
     hashed = msg_hash(msg)
     expected = "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"
     assert hashed == expected
-
-
-def test_service_unavailable(caplog):
-    e = Exception("test message")
-    context = {"item1": "test1", "item2": "test2"}
-    response = service_unavailable(e, context, test_logger)
-    assert response.status_code == 503
-    response = response.json
-    assert response["error"] == "test message"
-    assert response["context"] == context
-    assert caplog.records[0].msg == "Payload was: item1=test1,item2=test2"
-
-
-def test_service_unavailable_strip_infura_project_id():
-    """Test that service_unavilable strips out infura project IDs."""
-
-    context = {"item1": "test1", "item2": "test2"}
-
-    # HTTP Infura URL (rinkeby)
-    e = Exception(
-        "429 Client Error: Too Many Requests for url: "
-        "https://rinkeby.infura.io/v3/ffffffffffffffffffffffffffffffff"
-    )
-    response = service_unavailable(e, context, test_logger)
-    assert (
-        response.json["error"] == "429 Client Error: Too Many Requests for url: "
-        "https://rinkeby.infura.io/v3/<infura project id stripped for security reasons>"
-    )
-
-    # Websocket Infura URL (ropsten)
-    e = Exception(
-        "429 Client Error: Too Many Requests for url: "
-        "https://ropsten.infura.io/ws/v3/ffffffffffffffffffffffffffffffff"
-    )
-    response = service_unavailable(e, context, test_logger)
-    assert (
-        response.json["error"] == "429 Client Error: Too Many Requests for url: "
-        "https://ropsten.infura.io/ws/v3/<infura project id stripped for security reasons>"
-    )
-
-    # Other
-    e = Exception("anything .infura.io/v3/<any_non_whitespace_string>")
-    response = service_unavailable(e, context, test_logger)
-    assert (
-        response.json["error"]
-        == "anything .infura.io/v3/<infura project id stripped for security reasons>"
-    )
 
 
 def test_build_download_response():

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -346,7 +346,7 @@ def decode_from_data(data, key, dec_type="list"):
 
 
 def service_unavailable(error, context, custom_logger=None):
-    error = strip_infura_id(str(error))
+    error = strip_infura_project_id(str(error))
 
     text_items = []
     for key, value in context.items():
@@ -369,7 +369,7 @@ INFURA_ENDPOINT_WSS = ".infura.io/ws/v3/"
 STRIPPED_INFURA_ID_MSG = "<infura project id stripped for security reasons>"
 
 
-def strip_infura_id(error: str) -> str:
+def strip_infura_project_id(error: str) -> str:
     if INFURA_ENDPOINT_HTTPS in error:
         error = re.sub(
             rf"{INFURA_ENDPOINT_HTTPS}\S+",

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -352,7 +352,7 @@ def service_unavailable(error, context, custom_logger=None):
 
     logger_message = "Payload was: " + ",".join(text_items)
     custom_logger = custom_logger if custom_logger else logger
-    custom_logger.error(logger_message, exc_info=1)
+    custom_logger.error(f"error = {error}, input data = {logger_message}", exc_info=1)
 
     return Response(
         json.dumps({"error": str(error), "context": context}),

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -7,7 +7,6 @@ import json
 import logging
 import mimetypes
 import os
-import re
 from cgi import parse_header
 
 import requests
@@ -343,46 +342,6 @@ def decode_from_data(data, key, dec_type="list"):
             return -1
 
     return data
-
-
-def service_unavailable(error, context, custom_logger=None):
-    error = strip_infura_project_id(str(error))
-
-    text_items = []
-    for key, value in context.items():
-        value = value if isinstance(value, str) else json.dumps(value)
-        text_items.append(key + "=" + value)
-
-    logger_message = "Payload was: " + ",".join(text_items)
-    custom_logger = custom_logger if custom_logger else logger
-    custom_logger.error(f"error = {error}, input data = {logger_message}", exc_info=1)
-
-    return Response(
-        json.dumps({"error": str(error), "context": context}),
-        503,
-        headers={"content-type": "application/json"},
-    )
-
-
-INFURA_ENDPOINT_HTTPS = ".infura.io/v3/"
-INFURA_ENDPOINT_WSS = ".infura.io/ws/v3/"
-STRIPPED_INFURA_ID_MSG = "<infura project id stripped for security reasons>"
-
-
-def strip_infura_project_id(error: str) -> str:
-    if INFURA_ENDPOINT_HTTPS in error:
-        error = re.sub(
-            rf"{INFURA_ENDPOINT_HTTPS}\S+",
-            f"{INFURA_ENDPOINT_HTTPS}{STRIPPED_INFURA_ID_MSG}",
-            error,
-        )
-    if INFURA_ENDPOINT_WSS in error:
-        error = re.sub(
-            rf"{INFURA_ENDPOINT_WSS}\S+",
-            f"{INFURA_ENDPOINT_WSS}{STRIPPED_INFURA_ID_MSG}",
-            error,
-        )
-    return error
 
 
 def check_asset_consumable(asset, consumer_address, logger, custom_url=None):


### PR DESCRIPTION
Fixes #287

Changes proposed in this PR:

- Fix bug where `service_unavailable` would leak Infura project ID to the caller of provider endpoints.
- Add `strip_infura_project_id` utility
- Add `test_service_unavailable_strip_infura_project_id` unit test
- Move `service_unavailable` to `utils/error_responses.py`
- Move related unit tests to `utils/test/test_error_responses.py`
- Update log statement inside `service_unavailable` to print error message
- Various black formatting fixes