### PR TITLE
Strip all URLs, not just infura project ids (v3)

### DIFF
--- a/ocean_provider/utils/error_responses.py
+++ b/ocean_provider/utils/error_responses.py
@@ -4,19 +4,17 @@
 #
 import json
 import logging
-import re
 
 from flask.wrappers import Response
+from ocean_provider.utils.url import is_url
 
 logger = logging.getLogger(__name__)
 
-INFURA_ENDPOINT_HTTPS = ".infura.io/v3/"
-INFURA_ENDPOINT_WSS = ".infura.io/ws/v3/"
-STRIPPED_INFURA_PROJECT_ID_MSG = "<infura project id stripped for security reasons>"
+STRIPPED_URL_MSG = "<URL stripped for security reasons>"
 
 
 def service_unavailable(error, context, custom_logger=None):
-    error = strip_infura_project_id(str(error))
+    error = strip_and_replace_urls(str(error))
 
     text_items = []
     for key, value in context.items():
@@ -34,17 +32,8 @@ def service_unavailable(error, context, custom_logger=None):
     )
 
 
-def strip_infura_project_id(error: str) -> str:
-    if INFURA_ENDPOINT_HTTPS in error:
-        error = re.sub(
-            rf"{INFURA_ENDPOINT_HTTPS}\S+",
-            f"{INFURA_ENDPOINT_HTTPS}{STRIPPED_INFURA_PROJECT_ID_MSG}",
-            error,
-        )
-    if INFURA_ENDPOINT_WSS in error:
-        error = re.sub(
-            rf"{INFURA_ENDPOINT_WSS}\S+",
-            f"{INFURA_ENDPOINT_WSS}{STRIPPED_INFURA_PROJECT_ID_MSG}",
-            error,
-        )
-    return error
+def strip_and_replace_urls(err_str: str) -> str:
+    tokens = []
+    for token in err_str.split():
+        tokens += [STRIPPED_URL_MSG] if is_url(token) else [token]
+    return " ".join(tokens)

--- a/ocean_provider/utils/test/test_url.py
+++ b/ocean_provider/utils/test/test_url.py
@@ -4,16 +4,16 @@
 #
 import logging
 
-from ocean_provider.utils.url import is_safe_schema, is_safe_url, is_this_same_provider
+from ocean_provider.utils.url import is_safe_url, is_this_same_provider, is_url
 
 test_logger = logging.getLogger(__name__)
 
 
-def test_is_safe_schema():
-    assert is_safe_schema("https://jsonplaceholder.typicode.com/") is True
-    assert is_safe_schema("127.0.0.1") is False
-    assert is_safe_schema("169.254.169.254") is False
-    assert is_safe_schema("http://169.254.169.254/latest/meta-data/hostname") is True
+def test_is_url():
+    assert is_url("https://jsonplaceholder.typicode.com/") is True
+    assert is_url("127.0.0.1") is False
+    assert is_url("169.254.169.254") is False
+    assert is_url("http://169.254.169.254/latest/meta-data/hostname") is True
 
 
 def test_is_safe_url():

--- a/ocean_provider/utils/url.py
+++ b/ocean_provider/utils/url.py
@@ -6,19 +6,18 @@ import hashlib
 import ipaddress
 import json
 import logging
-import requests
 from urllib.parse import urlparse
 
 import dns.resolver
-from requests.models import PreparedRequest
-
+import requests
 from ocean_provider.utils.basics import get_config, get_provider_wallet
+from requests.models import PreparedRequest
 
 logger = logging.getLogger(__name__)
 
 
 def is_safe_url(url):
-    if not is_safe_schema(url):
+    if not is_url(url):
         return False
 
     result = urlparse(url)
@@ -26,7 +25,7 @@ def is_safe_url(url):
     return is_safe_domain(result.netloc)
 
 
-def is_safe_schema(url):
+def is_url(url):
     try:
         result = urlparse(url)
         return all([result.scheme, result.netloc])


### PR DESCRIPTION
Fixes #292 .

Changes proposed in this PR:

- Cherry-pick https://github.com/oceanprotocol/provider/commit/3c67cbb06b10242a35e1f1b30d2da4ada9baa7fa. This makes it so the `service_unavailable` function strips out all URLs, not just Infura project IDs.