### PR TITLE
Issue284 upgrade web3 py (v3)

### DIFF
--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -27,19 +27,14 @@ def mint(web3, contract, receiver_address, amount, minter_wallet):
         "from": minter_wallet.address,
         "account_key": str(minter_wallet.key),
         "chainId": web3.eth.chain_id,
+        "gasPrice": int(web3.eth.gas_price * 1.1),
     }
 
     return contract_fn.transact(_transact).hex()
 
 
 def verify_order_tx(
-    web3,
-    contract,
-    tx_id: str,
-    did: str,
-    service_id,
-    amount,
-    sender: str,
+    web3, contract, tx_id: str, did: str, service_id, amount, sender: str
 ):
     try:
         tx_receipt = get_tx_receipt(web3, tx_id)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md") as readme_file:
 install_requirements = [
     # Install ocean-utils first
     "ocean-contracts==0.6.7",
-    "web3==5.19.0",
+    "web3==5.25.0",
     "Flask==1.1.2",
     "Flask-Cors==3.0.9",
     "flask_caching==1.10.1",


### PR DESCRIPTION
Towards #284

Changes proposed in this PR:

- Upgrade web3.py to 5.25.0
- Add `gasPrice` to transactions, continue using legacy transaction type
- Add `get_gas_price` helper function
- Reformat via black, isort, flake