### PR TITLE
Fix computeEnvironment endpoint error handling

### DIFF
--- a/ocean_provider/utils/provider_fees.py
+++ b/ocean_provider/utils/provider_fees.py
@@ -68,18 +68,15 @@ def get_provider_fees(
 
 def get_c2d_environments() -> List:
     standard_headers = {"Content-type": "application/json", "Connection": "close"}
-    try:
-        response = requests_session.get(
-            get_compute_environments_endpoint(), headers=standard_headers
+    response = requests_session.get(
+        get_compute_environments_endpoint(), headers=standard_headers
+    )
+
+    # loop envs and add provider token from config
+    envs = response.json()
+    for env in envs:
+        env["feeToken"] = os.getenv(
+            "PROVIDER_FEE_TOKEN", "0x0000000000000000000000000000000000000000"
         )
 
-        # loop envs and add provider token from config
-        envs = response.json()
-        for env in envs:
-            env["feeToken"] = os.getenv(
-                "PROVIDER_FEE_TOKEN", "0x0000000000000000000000000000000000000000"
-            )
-
-        return envs
-    except Exception:
-        return []
+    return envs


### PR DESCRIPTION
Changes proposed in this PR:

- Fix computeEnvironment endpoint error handling. If exception occurs when calling c2d backend, let handle_error return 503, service unavailable.