### PR TITLE
Fix various issues of allow non public ip configuration

### DIFF
--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -135,7 +135,7 @@ class Config(configparser.ConfigParser):
 
     @property
     def allow_non_public_ip(self):
-        return self.get("resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=None)
+        return bool(int(self.get("resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=0)))
 
     @property
     def storage_path(self):

--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -375,7 +375,7 @@ def computeResult():
     update_nonce(data.get("consumerAddress"), data.get("nonce"))
 
     response = build_download_response(
-        request, requests_session, result_url, result_url, None
+        request, requests_session, result_url, result_url, None, False
     )
     logger.info(f"computeResult response = {response}")
 

--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -375,7 +375,7 @@ def computeResult():
     update_nonce(data.get("consumerAddress"), data.get("nonce"))
 
     response = build_download_response(
-        request, requests_session, result_url, result_url, None, False
+        request, requests_session, result_url, result_url, None, validate_url=False
     )
     logger.info(f"computeResult response = {response}")
 

--- a/ocean_provider/utils/url.py
+++ b/ocean_provider/utils/url.py
@@ -73,7 +73,7 @@ def is_safe_domain(domain):
     if not is_ip(domain):
         return result
 
-    return result and validate_dns_records(domain, domain, "")
+    return result and validate_dns_record(domain, domain, "")
 
 
 def validate_dns_records(domain, records, record_type):

--- a/ocean_provider/utils/url.py
+++ b/ocean_provider/utils/url.py
@@ -26,7 +26,7 @@ def is_safe_url(url):
 
     result = urlparse(url)
 
-    return is_safe_domain(result.netloc)
+    return is_safe_domain(result.hostname)
 
 
 def is_url(url):
@@ -99,7 +99,7 @@ def validate_dns_record(record, domain, record_type):
         ip = ipaddress.ip_address(value)
         # noqa See https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address.is_global
         if ip.is_private or ip.is_reserved or ip.is_loopback:
-            if allow_non_public_ip:
+            if allow_non_public_ip is True:
                 logger.warning(
                     f"[!] DNS record type {record_type} for domain name "
                     f"{domain} resolves to a non public IP address {value}, "

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -47,10 +47,10 @@ def msg_hash(message: str):
 
 
 def build_download_response(
-    request, requests_session, url, download_url, content_type=None, method="GET"
+    request, requests_session, url, download_url, content_type=None, method="GET", validate_url=True
 ):
     try:
-        if not is_safe_url(url):
+        if validate_url and not is_safe_url(url):
             raise ValueError(f"Unsafe url {url}")
         download_request_headers = {}
         download_response_headers = {}

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -47,7 +47,13 @@ def msg_hash(message: str):
 
 
 def build_download_response(
-    request, requests_session, url, download_url, content_type=None, method="GET", validate_url=True
+    request,
+    requests_session,
+    url,
+    download_url,
+    content_type=None,
+    method="GET",
+    validate_url=True,
 ):
     try:
         if validate_url and not is_safe_url(url):


### PR DESCRIPTION
Fixes #386 #391 #396

Changes proposed in this PR:

1. config.allow_non_public_ip() to return a Boolean type by setting ALLOW_NON_PUBLIC_IP environment variable as "0" or "1"
2. Validate DNS base on hostname instead of netloc (hostname:port) of an URL
3. Fix URL validation failure if a URL with IP and no Port been passed
4. GET /computeResult to skip the DNS validation, as an internal operator-api URL might be configured
