### PR TITLE
Fix allow allow_non_public_ip & add tests

### DIFF
--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -135,7 +135,15 @@ class Config(configparser.ConfigParser):
 
     @property
     def allow_non_public_ip(self):
-        return bool(int(self.get("resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=0)))
+        """Allow non public ip."""
+        should_allow_non_public_ip = self.get(
+            "resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=None
+        )
+        return should_allow_non_public_ip and should_allow_non_public_ip not in [
+            "false",
+            "False",
+            "0",
+        ]
 
     @property
     def storage_path(self):

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -8,6 +8,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 import configparser
+from distutils.util import strtobool
 import json
 import logging
 import os
@@ -139,11 +140,8 @@ class Config(configparser.ConfigParser):
         should_allow_non_public_ip = self.get(
             "resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=None
         )
-        return should_allow_non_public_ip and should_allow_non_public_ip not in [
-            "false",
-            "False",
-            "0",
-        ]
+
+        return bool(strtobool(should_allow_non_public_ip))
 
     @property
     def storage_path(self):

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -138,10 +138,10 @@ class Config(configparser.ConfigParser):
     def allow_non_public_ip(self):
         """Allow non public ip."""
         should_allow_non_public_ip = self.get(
-            "resources", NAME_ALLOW_NON_PUBLIC_IP, fallback=None
+            "resources", NAME_ALLOW_NON_PUBLIC_IP, fallback="false"
         )
 
-        return bool(strtobool(should_allow_non_public_ip))
+        return bool(strtobool(str(should_allow_non_public_ip)))
 
     @property
     def storage_path(self):

--- a/ocean_provider/test/test_config.py
+++ b/ocean_provider/test/test_config.py
@@ -53,7 +53,7 @@ def test_config_dict():
 
 
 @pytest.mark.unit
-def test_allow_non_public_ip():
+def test_allow_non_public_ip(monkeypatch):
     config_dict = {
         "eth-network": {},
         "resources": {
@@ -62,54 +62,28 @@ def test_allow_non_public_ip():
         },
     }
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == False
+    assert config.allow_non_public_ip is False
 
-    config_dict = {
-        "eth-network": {},
-        "resources": {
-            "aquarius.url": "https://another-aqua2.url",
-            "allow_non_public_ip": "0",
-        },
-    }
+    monkeypatch.setenv("ALLOW_NON_PUBLIC_IP", "0")
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == False
+    assert config.allow_non_public_ip is False
 
-    config_dict = {
-        "eth-network": {},
-        "resources": {
-            "aquarius.url": "https://another-aqua2.url",
-            "allow_non_public_ip": 0,
-        },
-    }
+    monkeypatch.setenv("ALLOW_NON_PUBLIC_IP", 0)
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == False
+    assert config.allow_non_public_ip is False
 
-    config_dict = {
-        "eth-network": {},
-        "resources": {
-            "aquarius.url": "https://another-aqua2.url",
-            "allow_non_public_ip": True,
-        },
-    }
+    monkeypatch.setenv("ALLOW_NON_PUBLIC_IP", True)
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == True
+    assert config.allow_non_public_ip is True
 
-    config_dict = {
-        "eth-network": {},
-        "resources": {
-            "aquarius.url": "https://another-aqua2.url",
-            "allow_non_public_ip": "True",
-        },
-    }
+    monkeypatch.setenv("ALLOW_NON_PUBLIC_IP", "True")
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == True
+    assert config.allow_non_public_ip is True
 
-    config_dict = {
-        "eth-network": {},
-        "resources": {
-            "aquarius.url": "https://another-aqua2.url",
-            "allow_non_public_ip": 1,
-        },
-    }
+    monkeypatch.setenv("ALLOW_NON_PUBLIC_IP", "1")
     config = Config(options_dict=config_dict)
-    assert config.allow_non_public_ip == True
+    assert config.allow_non_public_ip is True
+
+    monkeypatch.delenv("ALLOW_NON_PUBLIC_IP")
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip is False

--- a/ocean_provider/test/test_config.py
+++ b/ocean_provider/test/test_config.py
@@ -50,3 +50,66 @@ def test_config_dict():
     }
     config = Config(options_dict=config_dict)
     assert config.aquarius_url == "https://another-aqua2.url"
+
+
+@pytest.mark.unit
+def test_allow_non_public_ip():
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": "False",
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == False
+
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": "0",
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == False
+
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": 0,
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == False
+
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": True,
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == True
+
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": "True",
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == True
+
+    config_dict = {
+        "eth-network": {},
+        "resources": {
+            "aquarius.url": "https://another-aqua2.url",
+            "allow_non_public_ip": 1,
+        },
+    }
+    config = Config(options_dict=config_dict)
+    assert config.allow_non_public_ip == True

--- a/ocean_provider/utils/url.py
+++ b/ocean_provider/utils/url.py
@@ -99,7 +99,7 @@ def validate_dns_record(record, domain, record_type):
         ip = ipaddress.ip_address(value)
         # noqa See https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address.is_global
         if ip.is_private or ip.is_reserved or ip.is_loopback:
-            if allow_non_public_ip is True:
+            if allow_non_public_ip:
                 logger.warning(
                     f"[!] DNS record type {record_type} for domain name "
                     f"{domain} resolves to a non public IP address {value}, "


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #400  .

Changes proposed in this PR:

-  Fix errors in `allow_non_public_ip` from `config.py`