### PR TITLE
Log messages with asset url only if debug is enabled

### DIFF
--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -298,7 +298,7 @@ def computeStart():
 
     workflow = validator.workflow
     # workflow is ready, push it to operator
-    logger.info("Sending: %s", workflow)
+    logger.debug("Sending: %s", workflow)
 
     compute_env = data.get("environment")
     seconds = (

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -91,7 +91,7 @@ def fileinfo():
     return: list of file info (index, valid, contentLength, contentType)
     """
     data = get_request_data(request)
-    logger.info(f"fileinfo called. arguments = {data}")
+    logger.debug(f"fileinfo called. arguments = {data}")
     did = data.get("did")
     service_id = data.get("serviceId")
 
@@ -314,7 +314,7 @@ def download():
     valid, details = check_url_details(url_object["url"])
     content_type = details["contentType"] if valid else None
 
-    logger.info(
+    logger.debug(
         f"Done processing consume request for asset {did}, " f" url {download_url}"
     )
     update_nonce(consumer_address, data.get("nonce"))

--- a/ocean_provider/routes/encrypt.py
+++ b/ocean_provider/routes/encrypt.py
@@ -73,7 +73,7 @@ def encrypt():
         )
 
     data = request.get_data()
-    logger.info(f"encrypt called. arguments = {data}")
+    logger.debug(f"encrypt called. arguments = {data}")
 
     return _encrypt(data)
 


### PR DESCRIPTION
Changes proposed in this PR:

Set logging level to debug for all messages which logging the asset urls. 
Debug mode should be enabled only during development and usually not for production environment, which further prevent the asset url exposure to risk