### PR TITLE
Fix c2d address detection in download endpoint

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = True
 tag = True
 

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -278,7 +278,7 @@ def download():
 
     is_c2d_consumer_address = bool(
         [
-            Web3.toChecksumAddress(env["consumerAddress"])
+            True
             for env in c2d_environments
             if service.id == env["id"]
             and Web3.toChecksumAddress(env["consumerAddress"])

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -273,15 +273,20 @@ def download():
     asset = get_asset_from_metadatastore(get_metadata_url(), did)
     service = asset.get_service_by_id(service_id)
 
-    compute_address, compute_limits = (
-        get_compute_info() if os.getenv("OPERATOR_SERVICE_URL") else None,
-        None,
+    # allow our C2D to download a compute asset
+    c2d_environments = get_c2d_environments()
+
+    is_c2d_consumer_address = bool(
+        [
+            Web3.toChecksumAddress(env["consumerAddress"])
+            for env in c2d_environments
+            if service.id == env["id"]
+            and Web3.toChecksumAddress(env["consumerAddress"])
+            == Web3.toChecksumAddress(consumer_address)
+        ]
     )
 
-    # allow our C2D to download a compute asset
-    if service.type != ServiceType.ACCESS and Web3.toChecksumAddress(
-        consumer_address
-    ) != Web3.toChecksumAddress(compute_address):
+    if service.type != ServiceType.ACCESS and not is_c2d_consumer_address:
         return error_response(
             f"Service with index={service_id} is not an access service.", 400, logger
         )

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -280,8 +280,7 @@ def download():
         [
             True
             for env in c2d_environments
-            if service.id == env["id"]
-            and Web3.toChecksumAddress(env["consumerAddress"])
+            if Web3.toChecksumAddress(env["consumerAddress"])
             == Web3.toChecksumAddress(consumer_address)
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     url="https://github.com/oceanprotocol/provider-py",
     # fmt: off
     # bumpversion needs single quotes
-    version='1.0.3',
+    version='1.0.4',
     # fmt: on
     zip_safe=False,
 )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -245,8 +245,6 @@ def test_download_compute_asset_by_c2d(client, publisher_wallet, consumer_wallet
     nonce = str(datetime.utcnow().timestamp())
     _msg = f"{asset.did}{nonce}"
 
-    # Consume using url index and auth token
-    # (let the provider do the decryption)
     payload = {
         "documentId": asset.did,
         "serviceId": service.id,
@@ -257,15 +255,14 @@ def test_download_compute_asset_by_c2d(client, publisher_wallet, consumer_wallet
         "nonce": nonce,
     }
 
-    def other_service(*args, **kwargs):
+    def other_service(_):
         new_service = copy.deepcopy(service)
-        new_service.__setattr__("type", "compute")
+        new_service.type = "compute"
         return new_service
 
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
         mock.return_value = [
             {
-                "priceMin": 60,
                 "consumerAddress": consumer_wallet.address,
             }
         ]
@@ -301,8 +298,6 @@ def test_download_compute_asset_by_user_fails(
     nonce = str(datetime.utcnow().timestamp())
     _msg = f"{asset.did}{nonce}"
 
-    # Consume using url index and auth token
-    # (let the provider do the decryption)
     payload = {
         "documentId": asset.did,
         "serviceId": service.id,
@@ -313,15 +308,14 @@ def test_download_compute_asset_by_user_fails(
         "nonce": nonce,
     }
 
-    def other_service(*args, **kwargs):
+    def other_service(_):
         new_service = copy.deepcopy(service)
-        new_service.__setattr__("type", "compute")
+        new_service.type = "compute"
         return new_service
 
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
         mock.return_value = [
             {
-                "priceMin": 60,
                 "consumerAddress": "0x0000000000000000000000000000000000000123",
             }
         ]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,7 +2,9 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
+import copy
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 from ocean_provider.constants import BaseURLs
@@ -220,3 +222,119 @@ def test_download_multiple_files(client, publisher_wallet, consumer_wallet, web3
     download_endpoint = BaseURLs.SERVICES_URL + "/download"
     response = client.get(download_endpoint, query_string=payload)
     assert response.status_code == 200, f"{response.data}"
+
+
+@pytest.mark.integration
+def test_download_compute_asset_by_c2d(client, publisher_wallet, consumer_wallet, web3):
+    asset = get_dataset_ddo_with_multiple_files(client, publisher_wallet)
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+
+    # Consume using url index and auth token
+    # (let the provider do the decryption)
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "signature": sign_message(_msg, consumer_wallet),
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+        "nonce": nonce,
+    }
+
+    def other_service(*args, **kwargs):
+        new_service = copy.deepcopy(service)
+        new_service.__setattr__("type", "compute")
+        return new_service
+
+    with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
+        mock.return_value = [
+            {
+                "id": service.id,
+                "priceMin": 60,
+                "consumerAddress": consumer_wallet.address,
+            }
+        ]
+        with patch(
+            "ocean_provider.utils.asset.Asset.get_service_by_id",
+            side_effect=other_service,
+        ):
+            download_endpoint = BaseURLs.SERVICES_URL + "/download"
+            response = client.get(download_endpoint, query_string=payload)
+            assert response.status_code == 200, f"{response.data}"
+
+
+@pytest.mark.integration
+def test_download_compute_asset_by_user_fails(
+    client, publisher_wallet, consumer_wallet, web3
+):
+    asset = get_dataset_ddo_with_multiple_files(client, publisher_wallet)
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+
+    # Consume using url index and auth token
+    # (let the provider do the decryption)
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "signature": sign_message(_msg, consumer_wallet),
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+        "nonce": nonce,
+    }
+
+    def other_service(*args, **kwargs):
+        new_service = copy.deepcopy(service)
+        new_service.__setattr__("type", "compute")
+        return new_service
+
+    with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
+        mock.return_value = [
+            {
+                "id": service.id,
+                "priceMin": 60,
+                "consumerAddress": "0x0000000000000000000000000000000000000123",
+            }
+        ]
+        with patch(
+            "ocean_provider.utils.asset.Asset.get_service_by_id",
+            side_effect=other_service,
+        ):
+            download_endpoint = BaseURLs.SERVICES_URL + "/download"
+            response = client.get(download_endpoint, query_string=payload)
+            assert response.status_code == 400, f"{response.data}"
+            assert (
+                response.json["error"]
+                == f"Service with index={service.id} is not an access service."
+            )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -265,7 +265,6 @@ def test_download_compute_asset_by_c2d(client, publisher_wallet, consumer_wallet
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
         mock.return_value = [
             {
-                "id": service.id,
                 "priceMin": 60,
                 "consumerAddress": consumer_wallet.address,
             }
@@ -322,7 +321,6 @@ def test_download_compute_asset_by_user_fails(
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
         mock.return_value = [
             {
-                "id": service.id,
                 "priceMin": 60,
                 "consumerAddress": "0x0000000000000000000000000000000000000123",
             }


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

Fixes #418  .

Changes proposed in this PR:

- Retrieve c2d environments and compare consumer address with the service id to allow or block download