### PR TITLE
Removes error logging for 404 code.

### DIFF
--- a/ocean_provider/run.py
+++ b/ocean_provider/run.py
@@ -46,7 +46,8 @@ def handle_error(error):
     response.status_code = code
     response.headers["Connection"] = "close"
 
-    logger.error(f"error: {error}, payload: {request.data}", exc_info=1)
+    if code != 404:
+        logger.error(f"error: {error}, payload: {request.data}", exc_info=1)
 
     return response
 

--- a/ocean_provider/run.py
+++ b/ocean_provider/run.py
@@ -48,6 +48,8 @@ def handle_error(error):
 
     if code != 404:
         logger.error(f"error: {error}, payload: {request.data}", exc_info=1)
+    else:
+        logger.info(f"error: {str(error)}, payload: {request.data}")
 
     return response
 


### PR DESCRIPTION
Closes #423. It doesn't seem it was crashing, just logging the error. However, I think we shouldn't log 404 as errors. We already have the "incoming request" logger and I believe that to be enough.

Alternately I can log it as info, if needed.