### PR TITLE
Issue442 enforce order timeout

### DIFF
--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -185,16 +185,18 @@ def verify_order_tx(
             f"event: amount={order_log.args.amount}"
         )
 
-    timestamp_now = datetime.utcnow().timestamp()
-    timestamp_delta = timestamp_now - order_log.args.timestamp
-    if timestamp_delta > service.timeout:
-        raise ValueError(
-            f"The order has expired. \n"
-            f"current timestamp={timestamp_now}\n"
-            f"order timestamp={order_log.args.timestamp}\n"
-            f"timestamp delta={timestamp_delta}\n"
-            f"service timeout={service.timeout}"
-        )
+    # Check if order expired. timeout == 0 means order is valid forever
+    if service.timeout != 0:
+        timestamp_now = datetime.utcnow().timestamp()
+        timestamp_delta = timestamp_now - order_log.args.timestamp
+        if timestamp_delta > service.timeout:
+            raise ValueError(
+                f"The order has expired. \n"
+                f"current timestamp={timestamp_now}\n"
+                f"order timestamp={order_log.args.timestamp}\n"
+                f"timestamp delta={timestamp_delta}\n"
+                f"service timeout={service.timeout}"
+            )
 
     if sender not in [order_log.args.consumer, order_log.args.payer]:
         raise ValueError("sender of order transaction is not the consumer/payer.")

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -185,6 +185,17 @@ def verify_order_tx(
             f"event: amount={order_log.args.amount}"
         )
 
+    timestamp_now = datetime.utcnow().timestamp()
+    timestamp_delta = timestamp_now - order_log.args.timestamp
+    if timestamp_delta < service.timeout:
+        raise ValueError(
+            f"The order has expired. \n"
+            f"current timestamp={timestamp_now}\n"
+            f"order timestamp={order_log.args.timestamp}\n"
+            f"timestamp delta={timestamp_delta}\n"
+            f"service timeout={service.timeout}"
+        )
+
     if sender not in [order_log.args.consumer, order_log.args.payer]:
         raise ValueError("sender of order transaction is not the consumer/payer.")
 

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -187,7 +187,7 @@ def verify_order_tx(
 
     timestamp_now = datetime.utcnow().timestamp()
     timestamp_delta = timestamp_now - order_log.args.timestamp
-    if timestamp_delta < service.timeout:
+    if timestamp_delta > service.timeout:
         raise ValueError(
             f"The order has expired. \n"
             f"current timestamp={timestamp_now}\n"

--- a/ocean_provider/validation/test/test_algo_validation.py
+++ b/ocean_provider/validation/test/test_algo_validation.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import copy
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
 from ocean_provider.utils.asset import Asset
-from ocean_provider.utils.services import ServiceType, Service
+from ocean_provider.utils.services import Service, ServiceType
 from ocean_provider.validation.algo import WorkflowValidator
-from tests.ddo.ddo_sample1_compute import ddo_dict, alg_ddo_dict
+from tests.ddo.ddo_sample1_compute import alg_ddo_dict, ddo_dict
 from tests.helpers.compute_helpers import get_future_valid_until
 from tests.test_helpers import get_first_service_by_type
 
@@ -37,11 +37,7 @@ def test_passes_algo_ddo(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "documentId": alg_ddo.did,
             "serviceId": sa_compute.id,
@@ -79,11 +75,7 @@ def test_passes_raw(provider_wallet, consumer_address, web3):
     ddo = Asset(ddo_dict)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "serviceId": sa.id,
             "meta": {
@@ -123,11 +115,7 @@ def test_fails_not_an_algo(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "documentId": did,
             "serviceId": sa_compute.id,
@@ -167,15 +155,8 @@ def test_fails_meta_issues(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     """Tests happy flow of validator with algo ddo and raw algo."""
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
-        "algorithm": {
-            "serviceId": sa.id,
-            "meta": {},
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
+        "algorithm": {"serviceId": sa.id, "meta": {}},
     }
 
     with patch(
@@ -190,11 +171,7 @@ def test_fails_meta_issues(provider_wallet, consumer_address, web3):
 
     # algorithmMeta container is empty
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa.id,
             "meta": {
@@ -218,11 +195,7 @@ def test_fails_meta_issues(provider_wallet, consumer_address, web3):
 
     # algorithmMeta container is missing image
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa.id,
             "meta": {
@@ -262,11 +235,7 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "documentId": alg_ddo.did,
             "serviceId": sa_compute.id,
@@ -292,11 +261,7 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
 
     # additional input is invalid
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -313,11 +278,7 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
 
     # Missing did in additional input
     data = {
-        "dataset": {
-            "documentId": did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -338,11 +299,7 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
 
     # Did is not valid
     data = {
-        "dataset": {
-            "documentId": did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -369,11 +326,7 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
         )
 
     data = {
-        "dataset": {
-            "documentId": did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -417,11 +370,7 @@ def test_service_not_compute(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -444,7 +393,7 @@ def test_service_not_compute(provider_wallet, consumer_address, web3):
             datatoken_address="0xa",
             service_endpoint="test",
             encrypted_files="",
-            timeout=0,
+            timeout=3600,
         )
 
     with patch(
@@ -496,11 +445,7 @@ def test_fails_trusted(provider_wallet, consumer_address, web3):
             return trust_ddo
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -529,9 +474,7 @@ def test_fails_trusted(provider_wallet, consumer_address, web3):
     # Additional input has other trusted publishers
     _copy = copy.deepcopy(ddo_dict)
     _copy["id"] = "0xtrust"
-    _copy["services"][0]["compute"]["publisherTrustedAlgorithmPublishers"] = [
-        "0xabc",
-    ]
+    _copy["services"][0]["compute"]["publisherTrustedAlgorithmPublishers"] = ["0xabc"]
     _copy["services"][0]["id"] = "compute_2"
     trust_ddo = Asset(_copy)
     trust_sa = get_first_service_by_type(trust_ddo, ServiceType.COMPUTE)
@@ -574,23 +517,13 @@ def test_fails_trusted(provider_wallet, consumer_address, web3):
     "ocean_provider.validation.algo.validate_order",
     return_value=(None, None, provider_fees_event),
 )
-@patch(
-    "ocean_provider.validation.algo.get_service_files_list",
-    return_value=None,
-)
+@patch("ocean_provider.validation.algo.get_service_files_list", return_value=None)
 def test_fails_no_asset_url(provider_wallet, consumer_address, web3):
     ddo = Asset(ddo_dict)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
-        "algorithm": {
-            "serviceId": sa.id,
-            "meta": {},
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
+        "algorithm": {"serviceId": sa.id, "meta": {}},
     }
 
     with patch(
@@ -615,15 +548,8 @@ def test_fails_validate_order(provider_wallet, consumer_address, web3):
     ddo = Asset(ddo_dict)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
-        "algorithm": {
-            "serviceId": sa.id,
-            "meta": {},
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
+        "algorithm": {"serviceId": sa.id, "meta": {}},
     }
 
     with patch(
@@ -648,15 +574,8 @@ def test_fails_no_service_id(provider_wallet, consumer_address, web3):
     ddo = Asset(ddo_dict)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": None,
-            "transferTxId": "tx_id",
-        },
-        "algorithm": {
-            "serviceId": sa.id,
-            "meta": {},
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": None, "transferTxId": "tx_id"},
+        "algorithm": {"serviceId": sa.id, "meta": {}},
     }
 
     with patch(
@@ -688,11 +607,7 @@ def test_fails_invalid_algorithm_dict(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "documentId": alg_ddo.did,
             "serviceId": sa_compute.id,
@@ -733,11 +648,7 @@ def test_fails_algorithm_in_use(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "documentId": alg_ddo.did,
             "serviceId": sa_compute.id,
@@ -792,11 +703,7 @@ def test_fail_wrong_algo_type(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "documentId": alg_ddo.did,
@@ -819,7 +726,7 @@ def test_fail_wrong_algo_type(provider_wallet, consumer_address, web3):
             datatoken_address="0xa",
             service_endpoint="test",
             encrypted_files="",
-            timeout=0,
+            timeout=3600,
         )
 
     with patch(
@@ -852,11 +759,7 @@ def test_fail_allow_raw_false(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     ddo.services[0].compute_dict["allowRawAlgorithm"] = False
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "meta": {
@@ -897,11 +800,7 @@ def test_success_multiple_services_types(provider_wallet, consumer_address, web3
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
         "algorithm": {
             "serviceId": sa_compute.id,
             "meta": {
@@ -912,11 +811,7 @@ def test_success_multiple_services_types(provider_wallet, consumer_address, web3
             },
         },
         "additionalDatasets": [
-            {
-                "documentId": ddo.did,
-                "transferTxId": "ddo.did",
-                "serviceId": "access_1",
-            }
+            {"documentId": ddo.did, "transferTxId": "ddo.did", "serviceId": "access_1"}
         ],
     }
 
@@ -957,21 +852,10 @@ def test_fail_missing_algo_meta_documentId(provider_wallet, consumer_address, we
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "transferTxId": "tx_id",
-            "serviceId": sa.id,
-        },
-        "algorithm": {
-            "serviceId": None,
-            "meta": None,
-        },
+        "dataset": {"documentId": ddo.did, "transferTxId": "tx_id", "serviceId": sa.id},
+        "algorithm": {"serviceId": None, "meta": None},
         "additionalDatasets": [
-            {
-                "documentId": ddo.did,
-                "transferTxId": "ddo.did",
-                "serviceId": "access_1",
-            }
+            {"documentId": ddo.did, "transferTxId": "ddo.did", "serviceId": "access_1"}
         ],
     }
 
@@ -1022,11 +906,7 @@ def test_fee_amount_not_paid(provider_wallet, consumer_address, web3):
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
 
     data = {
-        "dataset": {
-            "documentId": ddo.did,
-            "serviceId": sa.id,
-            "transferTxId": "tx_id",
-        },
+        "dataset": {"documentId": ddo.did, "serviceId": sa.id, "transferTxId": "tx_id"},
         "algorithm": {
             "documentId": alg_ddo.did,
             "serviceId": sa_compute.id,
@@ -1045,10 +925,8 @@ def test_fee_amount_not_paid(provider_wallet, consumer_address, web3):
         "ocean_provider.validation.algo.get_asset_from_metadatastore",
         side_effect=side_effect,
     ):
-        with patch(
-            "ocean_provider.validation.algo.get_provider_fee_amount",
-        ) as mock:
-            mock.return_value = 10**18
+        with patch("ocean_provider.validation.algo.get_provider_fee_amount") as mock:
+            mock.return_value = 10 ** 18
             validator = WorkflowValidator(web3, consumer_address, provider_wallet, data)
             assert validator.validate() is False
             assert (

--- a/ocean_provider/validation/test/test_algo_validation.py
+++ b/ocean_provider/validation/test/test_algo_validation.py
@@ -926,7 +926,7 @@ def test_fee_amount_not_paid(provider_wallet, consumer_address, web3):
         side_effect=side_effect,
     ):
         with patch("ocean_provider.validation.algo.get_provider_fee_amount") as mock:
-            mock.return_value = 10 ** 18
+            mock.return_value = 10**18
             validator = WorkflowValidator(web3, consumer_address, provider_wallet, data)
             assert validator.validate() is False
             assert (

--- a/tests/helpers/ddo_dict_builders.py
+++ b/tests/helpers/ddo_dict_builders.py
@@ -5,16 +5,13 @@
 import json
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from eth_typing.encoding import HexStr
 from eth_typing.evm import HexAddress
-from web3.main import Web3
-
-from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.basics import get_provider_wallet
 from ocean_provider.utils.encryption import do_encrypt
-from ocean_provider.utils.services import Service
+from web3.main import Web3
 
 """Test helpers for building service dicts to be used in DDOs"""
 
@@ -70,7 +67,7 @@ def build_service_dict_type_access(
     datatoken_address: HexAddress,
     service_endpoint: str,
     encrypted_files: HexStr,
-    timeout: int = 3600,
+    timeout: int = 3600,  # 1 hour
 ) -> dict:
     """Build an access service dict, used for testing"""
     access_service = _build_service_dict_untyped(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -119,9 +119,9 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
     )
 
     if timeout == 1:
-        assert response.status_code == 400, f"{response.content}"
+        assert response.status_code == 400, f"{response.data}"
     else:
-        assert response.status_code == 200, f"{response.content}"
+        assert response.status_code == 200, f"{response.data}"
 
 
 @pytest.mark.unit

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -12,14 +12,9 @@ from ocean_provider.utils.accounts import sign_message
 from ocean_provider.utils.provider_fees import get_provider_fees
 from ocean_provider.utils.services import ServiceType
 from tests.test_helpers import (
-    get_dataset_ddo_disabled,
-    get_dataset_ddo_with_denied_consumer,
     get_dataset_ddo_with_multiple_files,
-    get_dataset_with_invalid_url_ddo,
-    get_dataset_with_ipfs_url_ddo,
     get_first_service_by_type,
     get_registered_asset,
-    initialize_service,
     mint_100_datatokens,
     start_order,
 )
@@ -86,6 +81,44 @@ def test_download_service(
         payload["transferTxId"] = "0x123"  # some dummy
         response = client.get(download_endpoint, query_string=payload)
         assert response.status_code == 400, f"{response.data}"
+
+
+def test_download_expired_timeout(client, publisher_wallet, consumer_wallet, web3):
+    asset = get_registered_asset(
+        publisher_wallet, custom_services="access_service_with_zero_timeout"
+    )
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+    }
+
+    download_endpoint = BaseURLs.SERVICES_URL + "/download"
+
+    # Consume using url index and signature (with nonce)
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+    payload["signature"] = sign_message(_msg, consumer_wallet)
+    payload["nonce"] = nonce
+    response = client.get(
+        service.service_endpoint + download_endpoint, query_string=payload
+    )
+    assert response.status_code == 400, f"{response.data}"
 
 
 @pytest.mark.unit
@@ -188,11 +221,7 @@ def test_download_compute_asset_by_c2d(client, publisher_wallet, consumer_wallet
         return new_service
 
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
-        mock.return_value = [
-            {
-                "consumerAddress": consumer_wallet.address,
-            }
-        ]
+        mock.return_value = [{"consumerAddress": consumer_wallet.address}]
         with patch(
             "ocean_provider.utils.asset.Asset.get_service_by_id",
             side_effect=other_service,
@@ -242,9 +271,7 @@ def test_download_compute_asset_by_user_fails(
 
     with patch("ocean_provider.routes.consume.get_c2d_environments") as mock:
         mock.return_value = [
-            {
-                "consumerAddress": "0x0000000000000000000000000000000000000123",
-            }
+            {"consumerAddress": "0x0000000000000000000000000000000000000123"}
         ]
         with patch(
             "ocean_provider.utils.asset.Asset.get_service_by_id",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -85,7 +85,7 @@ def test_download_service(
 
 def test_download_expired_timeout(client, publisher_wallet, consumer_wallet, web3):
     asset = get_registered_asset(
-        publisher_wallet, custom_services="access_service_with_zero_timeout"
+        publisher_wallet, custom_services="access_service_with_short_timeout"
     )
     service = get_first_service_by_type(asset, ServiceType.ACCESS)
     mint_100_datatokens(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -118,7 +118,7 @@ def test_download_expired_timeout(client, publisher_wallet, consumer_wallet, web
     response = client.get(
         service.service_endpoint + download_endpoint, query_string=payload
     )
-    assert response.status_code == 400, f"{response.data}"
+    assert response.status_code == 400, f"{response.content}"
 
 
 @pytest.mark.unit

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -83,10 +83,9 @@ def test_download_service(
         assert response.status_code == 400, f"{response.data}"
 
 
-def test_download_expired_timeout(client, publisher_wallet, consumer_wallet, web3):
-    asset = get_registered_asset(
-        publisher_wallet, custom_services="access_service_with_short_timeout"
-    )
+@pytest.mark.parametrize("timeout", [0, 1, 3600])
+def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeout):
+    asset = get_registered_asset(publisher_wallet, timeout=timeout)
     service = get_first_service_by_type(asset, ServiceType.ACCESS)
     mint_100_datatokens(
         web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
@@ -118,7 +117,11 @@ def test_download_expired_timeout(client, publisher_wallet, consumer_wallet, web
     response = client.get(
         service.service_endpoint + download_endpoint, query_string=payload
     )
-    assert response.status_code == 400, f"{response.content}"
+
+    if timeout == 1:
+        assert response.status_code == 400, f"{response.content}"
+    else:
+        assert response.status_code == 200, f"{response.content}"
 
 
 @pytest.mark.unit

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -90,6 +90,10 @@ def test_download_service(
 @pytest.mark.integration
 @pytest.mark.parametrize("timeout", [0, 1, 3600])
 def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeout):
+    """
+    If timeout == 0, order is valid forever
+    else reject request if current timestamp - order timestamp > timeout
+    """
     asset = get_registered_asset(publisher_wallet, timeout=timeout)
     service = get_first_service_by_type(asset, ServiceType.ACCESS)
     mint_100_datatokens(
@@ -123,7 +127,7 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
         service.service_endpoint + download_endpoint, query_string=payload
     )
 
-    # Expect failure if timeout is only 1 second. Expect success otherwise
+    # Expect failure if timeout is 1 second. Expect success otherwise
     if timeout == 1:
         assert response.status_code == 400, f"{response.data}"
     else:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -119,6 +119,7 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
         service.service_endpoint + download_endpoint, query_string=payload
     )
 
+    # Expect failure if timeout is only 1 second. Expect success otherwise
     if timeout == 1:
         assert response.status_code == 400, f"{response.data}"
     else:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -43,9 +43,6 @@ def test_download_service(
         consumer_wallet,
     )
 
-    # Sleept for 1 second (give the order time to expire)
-    time.sleep(1)
-
     payload = {
         "documentId": asset.did,
         "serviceId": service.id,
@@ -107,6 +104,9 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
         get_provider_fees(asset.did, service, consumer_wallet.address, 0),
         consumer_wallet,
     )
+
+    # Sleep for 1 second (give the order time to expire)
+    time.sleep(1)
 
     payload = {
         "documentId": asset.did,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -83,6 +83,7 @@ def test_download_service(
         assert response.status_code == 400, f"{response.data}"
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("timeout", [0, 1, 3600])
 def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeout):
     asset = get_registered_asset(publisher_wallet, timeout=timeout)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import copy
+import time
 from datetime import datetime
 from unittest.mock import patch
 
@@ -41,6 +42,9 @@ def test_download_service(
         get_provider_fees(asset.did, service, consumer_wallet.address, 0),
         consumer_wallet,
     )
+
+    # Sleept for 1 second (give the order time to expire)
+    time.sleep(1)
 
     payload = {
         "documentId": asset.did,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -466,6 +466,12 @@ def build_custom_services(
         return [
             get_compute_service_no_rawalgo(from_wallet.address, 10, datatoken_address)
         ]
+    if services_type == "access_service_with_zero_timeout":
+        return [
+            build_service_dict_type_access(
+                datatoken_address, service_endpoint, encrypted_files, timeout=0
+            )
+        ]
 
     return []
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,11 +18,7 @@ from flask.testing import FlaskClient
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.address import get_contract_address
 from ocean_provider.utils.asset import get_asset_from_metadatastore
-from ocean_provider.utils.basics import (
-    get_config,
-    get_provider_wallet,
-    get_web3,
-)
+from ocean_provider.utils.basics import get_config, get_provider_wallet, get_web3
 from ocean_provider.utils.currency import to_wei
 from ocean_provider.utils.data_nft import Flags, MetadataState, get_data_nft_contract
 from ocean_provider.utils.data_nft_factory import get_data_nft_factory_contract
@@ -239,7 +235,12 @@ def get_registered_asset(
         ]
         if not custom_services
         else build_custom_services(
-            custom_services, from_wallet, web3, data_nft_address, custom_services_args
+            custom_services,
+            from_wallet,
+            datatoken_address,
+            service_endpoint,
+            encrypted_files,
+            custom_services_args,
         )
     )
 
@@ -445,23 +446,13 @@ def start_order(
 
 
 def build_custom_services(
-    services_type, from_wallet, web3, data_nft_address, custom_services_args
+    services_type,
+    from_wallet,
+    datatoken_address,
+    service_endpoint,
+    encrypted_files,
+    custom_services_args,
 ):
-    datatoken_address = deploy_datatoken(
-        web3=web3,
-        data_nft_address=data_nft_address,
-        template_index=1,
-        name="Datatoken 1",
-        symbol="DT1",
-        minter=from_wallet.address,
-        fee_manager=from_wallet.address,
-        publishing_market=BLACK_HOLE_ADDRESS,
-        publishing_market_fee_token=get_ocean_token_address(web3),
-        cap=to_wei(1000),
-        publishing_market_fee_amount=0,
-        from_wallet=from_wallet,
-    )
-
     if services_type == "vanilla_compute":
         return [
             get_compute_service(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -466,10 +466,10 @@ def build_custom_services(
         return [
             get_compute_service_no_rawalgo(from_wallet.address, 10, datatoken_address)
         ]
-    if services_type == "access_service_with_zero_timeout":
+    if services_type == "access_service_with_short_timeout":
         return [
             build_service_dict_type_access(
-                datatoken_address, service_endpoint, encrypted_files, timeout=0
+                datatoken_address, service_endpoint, encrypted_files, timeout=1
             )
         ]
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -167,6 +167,7 @@ def get_registered_asset(
     custom_services_args=None,
     custom_service_endpoint=None,
     erc20_enterprise=False,
+    timeout=3600,
 ):
     web3 = get_web3()
     data_nft_address = deploy_data_nft(
@@ -231,16 +232,12 @@ def get_registered_asset(
                 datatoken_address=datatoken_address,
                 service_endpoint=service_endpoint,
                 encrypted_files=encrypted_files,
+                timeout=timeout,
             )
         ]
         if not custom_services
         else build_custom_services(
-            custom_services,
-            from_wallet,
-            datatoken_address,
-            service_endpoint,
-            encrypted_files,
-            custom_services_args,
+            custom_services, from_wallet, datatoken_address, custom_services_args
         )
     )
 
@@ -446,12 +443,7 @@ def start_order(
 
 
 def build_custom_services(
-    services_type,
-    from_wallet,
-    datatoken_address,
-    service_endpoint,
-    encrypted_files,
-    custom_services_args,
+    services_type, from_wallet, datatoken_address, custom_services_args
 ):
     if services_type == "vanilla_compute":
         return [
@@ -465,12 +457,6 @@ def build_custom_services(
     if services_type == "norawalgo":
         return [
             get_compute_service_no_rawalgo(from_wallet.address, 10, datatoken_address)
-        ]
-    if services_type == "access_service_with_short_timeout":
-        return [
-            build_service_dict_type_access(
-                datatoken_address, service_endpoint, encrypted_files, timeout=1
-            )
         ]
 
     return []


### PR DESCRIPTION
Fixes #442.

Changes proposed in this PR:

- Enforce order timeout when consuming an asset (download or c2d).  If timeout == 0, order valid forever. else, reject request if current timestamp - order timestamp > timeout.
- Add `test_download_timeout` integration test 
- Formatting changes using black, isort, and flake8