### PR TITLE
Issue442 enforce order timeout v3

### DIFF
--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -13,12 +13,11 @@ from ocean_provider.requests_session import get_requests_session
 from ocean_provider.user_nonce import get_nonce, increment_nonce
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
-    get_datatoken_minter,
     get_metadata_url,
     get_provider_wallet,
     get_web3,
 )
-from ocean_provider.utils.datatoken import get_dt_contract
+from ocean_provider.utils.datatoken import get_datatoken_minter, get_dt_contract
 from ocean_provider.utils.did import did_to_id
 from ocean_provider.utils.encryption import do_encrypt
 from ocean_provider.utils.error_responses import service_unavailable

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -9,12 +9,12 @@ from eth_utils import add_0x_prefix
 from flask import Response, jsonify, request
 from flask_sieve import validate
 from ocean_provider.log import setup_logging
-from ocean_provider.myapp import app
 from ocean_provider.requests_session import get_requests_session
 from ocean_provider.user_nonce import get_nonce, increment_nonce
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
     get_datatoken_minter,
+    get_metadata_url,
     get_provider_wallet,
     get_web3,
 )
@@ -27,11 +27,10 @@ from ocean_provider.utils.util import (
     build_download_response,
     check_asset_consumable,
     get_asset_download_urls,
-    get_asset_urls,
     get_asset_url_at_index,
+    get_asset_urls,
     get_compute_info,
     get_download_url,
-    get_metadata_url,
     get_request_data,
     process_consume_request,
     record_consume_request,

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -20,7 +20,7 @@ from ocean_provider.utils.basics import (
 from ocean_provider.utils.datatoken import get_datatoken_minter, get_dt_contract
 from ocean_provider.utils.did import did_to_id
 from ocean_provider.utils.encryption import do_encrypt
-from ocean_provider.utils.error_responses import service_unavailable
+from ocean_provider.utils.error_responses import error_response, service_unavailable
 from ocean_provider.utils.url import append_userdata, check_url_details
 from ocean_provider.utils.util import (
     build_download_response,
@@ -329,15 +329,23 @@ def download():
             return jsonify(error=message), 400
 
         logger.info("validate_order called from download endpoint.")
-        _tx, _order_log, _transfer_log = validate_order(
-            get_web3(),
-            consumer_address,
-            token_address,
-            service.get_cost(),
-            tx_id,
-            did,
-            service,
-        )
+        try:
+            _tx, _order_log, _transfer_log = validate_order(
+                get_web3(),
+                consumer_address,
+                token_address,
+                service.get_cost(),
+                tx_id,
+                did,
+                service,
+            )
+        except Exception as e:
+            return error_response(
+                f"=Order with tx_id {tx_id} could not be validated due to error: {e}",
+                400,
+                logger,
+            )
+
         validate_transfer_not_used_for_other_service(
             did, service_id, tx_id, consumer_address, token_address
         )

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -337,7 +337,8 @@ def download():
                 service.get_cost(),
                 tx_id,
                 did,
-                service,
+                service_id,
+                service.main["timeout"],
             )
         except Exception as e:
             return error_response(

--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -336,7 +336,7 @@ def download():
             service.get_cost(),
             tx_id,
             did,
-            service_id,
+            service,
         )
         validate_transfer_not_used_for_other_service(
             did, service_id, tx_id, consumer_address, token_address

--- a/ocean_provider/serializers.py
+++ b/ocean_provider/serializers.py
@@ -4,9 +4,9 @@
 #
 import json
 
-from ocean_provider.utils.basics import get_asset_from_metadatastore
+from ocean_provider.utils.basics import get_asset_from_metadatastore, get_metadata_url
 from ocean_provider.utils.url import append_userdata
-from ocean_provider.utils.util import get_asset_url_at_index, get_metadata_url
+from ocean_provider.utils.util import get_asset_url_at_index
 
 
 class StageAlgoSerializer:

--- a/ocean_provider/utils/asset.py
+++ b/ocean_provider/utils/asset.py
@@ -78,7 +78,7 @@ class Asset:
 
         self.other_values = values
 
-    def get_service(self, service_type: str):
+    def get_service(self, service_type: str) -> Service:
         """Return a service using."""
         return next(
             (service for service in self.services if service.type == service_type), None

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -13,8 +13,6 @@ from hexbytes import HexBytes
 from ocean_provider.config import Config
 from ocean_provider.http_provider import CustomHTTPProvider
 from ocean_provider.utils.asset import Asset
-from ocean_provider.utils.datatoken import get_dt_contract
-from requests_testadapter import Resp
 from web3 import WebsocketProvider
 from web3.main import Web3
 
@@ -53,15 +51,6 @@ def get_provider_wallet(web3: Optional[Web3] = None):
         )
 
     return wallet
-
-
-def get_datatoken_minter(datatoken_address):
-    """
-    :return: Eth account address of the Datatoken minter
-    """
-    dt = get_dt_contract(get_web3(), datatoken_address)
-    publisher = dt.caller.minter()
-    return publisher
 
 
 def get_artifacts_path():

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -28,6 +28,10 @@ def get_config(config_file: Optional[str] = None) -> Config:
     )
 
 
+def get_metadata_url():
+    return get_config().aquarius_url
+
+
 def get_provider_wallet(web3: Optional[Web3] = None):
     """
     :return: Wallet instance

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -1,9 +1,9 @@
 import datetime
 
+from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate
 from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
-from jsonsempai import magic  # noqa: F401
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
     get_metadata_url,

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -92,12 +92,12 @@ def verify_order_tx(
 
     # Check if order expired. timeout == 0 means order is valid forever
     service_timeout = service.main["timeout"]
+    timestamp_now = datetime.utcnow().timestamp()
+    timestamp_delta = timestamp_now - order_log.args.timestamp
+    logger.debug(
+        f"verify_order_tx: service timeout = {service_timeout}, timestamp delta = {timestamp_delta}"
+    )
     if service_timeout != 0:
-        timestamp_now = datetime.utcnow().timestamp()
-        timestamp_delta = timestamp_now - order_log.args.timestamp
-        logger.debug(
-            f"verify_order_tx: service timeout = {service_timeout}, timestamp delta = {timestamp_delta}"
-        )
         if timestamp_delta > service_timeout:
             raise ValueError(
                 f"The order has expired. \n"

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -92,11 +92,12 @@ def verify_order_tx(
 
     # Check if order expired. timeout == 0 means order is valid forever
     service_timeout = service.main["timeout"]
-    logger.info(f"service timeout = {service_timeout}")
     if service_timeout != 0:
         timestamp_now = datetime.utcnow().timestamp()
         timestamp_delta = timestamp_now - order_log.args.timestamp
-        logger.info(f"timestamp delta = {timestamp_delta}")
+        logger.debug(
+            f"verify_order_tx: service timeout = {service_timeout}, timestamp delta = {timestamp_delta}"
+        )
         if timestamp_delta > service_timeout:
             raise ValueError(
                 f"The order has expired. \n"

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -97,15 +97,14 @@ def verify_order_tx(
     logger.debug(
         f"verify_order_tx: service timeout = {service_timeout}, timestamp delta = {timestamp_delta}"
     )
-    if service_timeout != 0:
-        if timestamp_delta > service_timeout:
-            raise ValueError(
-                f"The order has expired. \n"
-                f"current timestamp={timestamp_now}\n"
-                f"order timestamp={order_log.args.timestamp}\n"
-                f"timestamp delta={timestamp_delta}\n"
-                f"service timeout={service_timeout}"
-            )
+    if service_timeout != 0 and timestamp_delta > service_timeout:
+        raise ValueError(
+            f"The order has expired. \n"
+            f"current timestamp={timestamp_now}\n"
+            f"order timestamp={order_log.args.timestamp}\n"
+            f"timestamp delta={timestamp_delta}\n"
+            f"service timeout={service_timeout}"
+        )
 
     target_amount = amount - contract.caller.calculateFee(amount, OPF_FEE_PER_TOKEN)
     if order_log.args.mrktFeeCollector and order_log.args.marketFee > 0:

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -1,12 +1,15 @@
 import datetime
 
-from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate
 from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
-from ocean_provider.utils.basics import get_asset_from_metadatastore, get_web3
+from jsonsempai import magic  # noqa: F401
+from ocean_provider.utils.basics import (
+    get_asset_from_metadatastore,
+    get_metadata_url,
+    get_web3,
+)
 from ocean_provider.utils.currency import to_wei
-from ocean_provider.utils.util import get_metadata_url
 from web3.logs import DISCARD
 from websockets import ConnectionClosed
 

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -4,7 +4,7 @@ from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate
 from eth_utils import remove_0x_prefix
 from hexbytes import HexBytes
-from ocean_provider.utils.basics import get_asset_from_metadatastore
+from ocean_provider.utils.basics import get_asset_from_metadatastore, get_web3
 from ocean_provider.utils.currency import to_wei
 from ocean_provider.utils.util import get_metadata_url
 from web3.logs import DISCARD
@@ -22,6 +22,15 @@ def get_dt_contract(web3, address):
 
 def get_tx_receipt(web3, tx_hash):
     return web3.eth.wait_for_transaction_receipt(HexBytes(tx_hash), timeout=120)
+
+
+def get_datatoken_minter(datatoken_address):
+    """
+    :return: Eth account address of the Datatoken minter
+    """
+    dt = get_dt_contract(get_web3(), datatoken_address)
+    publisher = dt.caller.minter()
+    return publisher
 
 
 def mint(web3, contract, receiver_address, amount, minter_wallet):

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from jsonsempai import magic  # noqa: F401
@@ -12,6 +13,8 @@ from websockets import ConnectionClosed
 
 OPF_FEE_PER_TOKEN = to_wei("0.001")  # 0.1%
 MAX_MARKET_FEE_PER_TOKEN = to_wei("0.001")
+
+logger = logging.getLogger(__name__)
 
 
 def get_dt_contract(web3, address):
@@ -89,9 +92,11 @@ def verify_order_tx(
 
     # Check if order expired. timeout == 0 means order is valid forever
     service_timeout = service.main["timeout"]
+    logger.info(f"service timeout = {service_timeout}")
     if service_timeout != 0:
         timestamp_now = datetime.utcnow().timestamp()
         timestamp_delta = timestamp_now - order_log.args.timestamp
+        logger.info(f"timestamp delta = {timestamp_delta}")
         if timestamp_delta > service_timeout:
             raise ValueError(
                 f"The order has expired. \n"

--- a/ocean_provider/utils/error_responses.py
+++ b/ocean_provider/utils/error_responses.py
@@ -5,6 +5,7 @@
 import json
 import logging
 
+from flask import jsonify, make_response
 from flask.wrappers import Response
 from ocean_provider.utils.url import is_url
 
@@ -30,6 +31,18 @@ def service_unavailable(error, context, custom_logger=None):
         503,
         headers={"content-type": "application/json"},
     )
+
+
+def error_response(err_str: str, status: int, custom_logger=None):
+    """Logs error and returns an error response."""
+    err_str = strip_and_replace_urls(str(err_str))
+
+    this_logger = custom_logger if custom_logger else logger
+    this_logger.error(err_str, exc_info=1)
+    response = make_response(jsonify(error=err_str), status)
+    response.headers["Connection"] = "close"
+
+    return response
 
 
 def strip_and_replace_urls(err_str: str) -> str:

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -17,6 +17,7 @@ from ocean_provider.utils.accounts import sign_message
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
     get_config,
+    get_metadata_url,
     get_provider_wallet,
 )
 from ocean_provider.utils.consumable import ConsumableCodes
@@ -28,10 +29,6 @@ from websockets import ConnectionClosed
 
 setup_logging()
 logger = logging.getLogger(__name__)
-
-
-def get_metadata_url():
-    return get_config().aquarius_url
 
 
 def get_request_data(request):

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -215,9 +215,9 @@ def get_compute_info():
         return None, None
 
 
-def validate_order(web3, sender, token_address, num_tokens, tx_id, did, service_id):
+def validate_order(web3, sender, token_address, num_tokens, tx_id, did, service):
     logger.debug(
-        f"validate_order: did={did}, service_id={service_id}, tx_id={tx_id}, "
+        f"validate_order: did={did}, service_id={service.index}, tx_id={tx_id}, "
         f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}"
     )
 
@@ -231,10 +231,10 @@ def validate_order(web3, sender, token_address, num_tokens, tx_id, did, service_
         i += 1
         try:
             tx, order_event, transfer_event = verify_order_tx(
-                web3, dt_contract, tx_id, did, int(service_id), amount, sender
+                web3, dt_contract, tx_id, did, service, amount, sender
             )
             logger.debug(
-                f"validate_order succeeded for: did={did}, service_id={service_id}, tx_id={tx_id}, "
+                f"validate_order succeeded for: did={did}, service_id={service.index}, tx_id={tx_id}, "
                 f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}. "
                 f"result is: tx={tx}, order_event={order_event}, transfer_event={transfer_event}"
             )

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -215,10 +215,13 @@ def get_compute_info():
         return None, None
 
 
-def validate_order(web3, sender, token_address, num_tokens, tx_id, did, service):
+def validate_order(
+    web3, sender, token_address, num_tokens, tx_id, did, service_id, service_timeout
+):
     logger.debug(
-        f"validate_order: did={did}, service_id={service.index}, tx_id={tx_id}, "
-        f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}"
+        f"validate_order: did={did}, service_id={service_id}, tx_id={tx_id}, "
+        f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}, "
+        f"service_timeout={service_timeout}."
     )
 
     dt_contract = get_dt_contract(web3, token_address)
@@ -231,11 +234,19 @@ def validate_order(web3, sender, token_address, num_tokens, tx_id, did, service)
         i += 1
         try:
             tx, order_event, transfer_event = verify_order_tx(
-                web3, dt_contract, tx_id, did, service, amount, sender
+                web3,
+                dt_contract,
+                tx_id,
+                did,
+                int(service_id),
+                amount,
+                sender,
+                service_timeout,
             )
             logger.debug(
-                f"validate_order succeeded for: did={did}, service_id={service.index}, tx_id={tx_id}, "
-                f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}. "
+                f"validate_order succeeded for: did={did}, service_id={service_id}, tx_id={tx_id}, "
+                f"sender={sender}, num_tokens={num_tokens}, token_address={token_address}, "
+                f"service_timeout={service_timeout}. "
                 f"result is: tx={tx}, order_event={order_event}, transfer_event={transfer_event}"
             )
 

--- a/ocean_provider/validation/algo.py
+++ b/ocean_provider/validation/algo.py
@@ -183,7 +183,7 @@ class WorkflowValidator:
                     add_0x_prefix(did_to_id(algorithm_did))
                     if algorithm_did.startswith("did:")
                     else algorithm_did,
-                    self.algo_service.index,
+                    self.algo_service,
                 )
                 validate_transfer_not_used_for_other_service(
                     algorithm_did,
@@ -436,7 +436,7 @@ class InputItemValidator:
                 add_0x_prefix(did_to_id(self.did))
                 if self.did.startswith("did:")
                 else self.did,
-                self.service.index,
+                self.service,
             )
             validate_transfer_not_used_for_other_service(
                 self.did,

--- a/ocean_provider/validation/algo.py
+++ b/ocean_provider/validation/algo.py
@@ -6,12 +6,13 @@ import json
 import logging
 
 from eth_utils import add_0x_prefix
-from web3.logs import DISCARD
-
 from ocean_provider.constants import BaseURLs
-from ocean_provider.myapp import app
 from ocean_provider.serializers import StageAlgoSerializer
-from ocean_provider.utils.basics import get_asset_from_metadatastore, get_config
+from ocean_provider.utils.basics import (
+    get_asset_from_metadatastore,
+    get_config,
+    get_metadata_url,
+)
 from ocean_provider.utils.datatoken import get_dt_contract, get_tx_receipt
 from ocean_provider.utils.did import did_to_id
 from ocean_provider.utils.url import append_userdata
@@ -21,12 +22,12 @@ from ocean_provider.utils.util import (
     filter_dictionary,
     filter_dictionary_starts_with,
     get_asset_download_urls,
-    get_metadata_url,
     msg_hash,
     record_consume_request,
     validate_order,
     validate_transfer_not_used_for_other_service,
 )
+from web3.logs import DISCARD
 
 logger = logging.getLogger(__name__)
 
@@ -346,7 +347,7 @@ class InputItemValidator:
 
         if trusted_publishers:
             algo_ddo = get_asset_from_metadatastore(get_metadata_url(), algorithm_did)
-            if not algo_ddo.publisher in trusted_publishers:
+            if algo_ddo.publisher not in trusted_publishers:
                 self.error = "this algorithm is not from a trusted publisher"
                 return False
 

--- a/ocean_provider/validation/algo.py
+++ b/ocean_provider/validation/algo.py
@@ -183,7 +183,8 @@ class WorkflowValidator:
                     add_0x_prefix(did_to_id(algorithm_did))
                     if algorithm_did.startswith("did:")
                     else algorithm_did,
-                    self.algo_service,
+                    self.algo_service.index,
+                    self.algo_service.main["timeout"],
                 )
                 validate_transfer_not_used_for_other_service(
                     algorithm_did,
@@ -436,7 +437,8 @@ class InputItemValidator:
                 add_0x_prefix(did_to_id(self.did))
                 if self.did.startswith("did:")
                 else self.did,
-                self.service,
+                self.service.index,
+                self.service.main["timeout"],
             )
             validate_transfer_not_used_for_other_service(
                 self.did,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -74,9 +74,8 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
     If timeout == 0, order is valid forever
     else reject request if current timestamp - order timestamp > timeout
     """
-    asset = get_dataset_ddo_with_access_service(client, publisher_wallet)
+    asset = get_dataset_ddo_with_access_service(client, publisher_wallet, timeout)
     service = asset.get_service("access")
-    service.main["timeout"] = timeout
 
     dt_token = get_dt_contract(web3, asset.data_token_address)
     mint_tokens_and_wait(dt_token, consumer_wallet, publisher_wallet)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,8 +2,9 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-import pytest
+import time
 
+import pytest
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.accounts import generate_auth_token, sign_message
 from ocean_provider.utils.datatoken import get_dt_contract
@@ -65,6 +66,46 @@ def test_download_service(client, publisher_wallet, consumer_wallet, web3, userd
     payload["signature"] = sign_message(_msg, consumer_wallet)
     response = client.get(download_endpoint, query_string=payload)
     assert response.status_code == 200, f"{response.data}"
+
+
+@pytest.mark.parametrize("timeout", [0, 1, 3600])
+def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeout):
+    """
+    If timeout == 0, order is valid forever
+    else reject request if current timestamp - order timestamp > timeout
+    """
+    asset = get_dataset_ddo_with_access_service(client, publisher_wallet)
+    service = asset.get_service("access")
+
+    dt_token = get_dt_contract(web3, asset.data_token_address)
+    mint_tokens_and_wait(dt_token, consumer_wallet, publisher_wallet)
+
+    tx_id = send_order(client, asset, dt_token, service, consumer_wallet)
+
+    # Sleep for 1 second (give the order time to expire)
+    time.sleep(1)
+
+    # Consume using url index and auth token
+    # (let the provider do the decryption)
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.index,
+        "serviceType": service.type,
+        "dataToken": asset.data_token_address,
+        "consumerAddress": consumer_wallet.address,
+        "signature": generate_auth_token(consumer_wallet),
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+    }
+
+    download_endpoint = BaseURLs.ASSETS_URL + "/download"
+    response = client.get(download_endpoint, query_string=payload)
+
+    # Expect failure if timeout is 1 second. Expect success otherwise
+    if timeout == 1:
+        assert response.status_code == 400, f"{response.data}"
+    else:
+        assert response.status_code == 200, f"{response.data}"
 
 
 def test_empty_payload(client):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -82,8 +82,8 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
 
     tx_id = send_order(client, asset, dt_token, service, consumer_wallet)
 
-    # Sleep for 1 second (give the order time to expire)
-    time.sleep(1)
+    # Sleep for 2 seconds (give the order time to expire)
+    time.sleep(2)
 
     # Consume using url index and auth token
     # (let the provider do the decryption)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -76,14 +76,15 @@ def test_download_timeout(client, publisher_wallet, consumer_wallet, web3, timeo
     """
     asset = get_dataset_ddo_with_access_service(client, publisher_wallet)
     service = asset.get_service("access")
+    service.main["timeout"] = timeout
 
     dt_token = get_dt_contract(web3, asset.data_token_address)
     mint_tokens_and_wait(dt_token, consumer_wallet, publisher_wallet)
 
     tx_id = send_order(client, asset, dt_token, service, consumer_wallet)
 
-    # Sleep for 2 seconds (give the order time to expire)
-    time.sleep(2)
+    # Sleep for 1 seconds (give the order time to expire)
+    time.sleep(1)
 
     # Consume using url index and auth token
     # (let the provider do the decryption)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,20 +12,15 @@ from datetime import datetime
 from pathlib import Path
 
 import ipfshttpclient
+from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate, Metadata
 from eth_account import Account
 from eth_utils import add_0x_prefix, remove_0x_prefix
-from jsonsempai import magic  # noqa: F401
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.asset import Asset
 from ocean_provider.utils.basics import get_asset_from_metadatastore, get_web3
 from ocean_provider.utils.currency import to_wei
-from ocean_provider.utils.datatoken import (
-    get_datatoken_minter,
-    get_tx_receipt,
-    mint,
-    verify_order_tx,
-)
+from ocean_provider.utils.datatoken import get_datatoken_minter, get_tx_receipt, mint
 from ocean_provider.utils.encryption import do_encrypt
 from ocean_provider.utils.services import Service
 from ocean_provider.utils.util import checksum
@@ -455,7 +450,4 @@ def send_order(client, ddo, datatoken, service, cons_wallet, expect_failure=Fals
 
     web3.eth.wait_for_transaction_receipt(tx_id)
 
-    verify_order_tx(
-        web3, datatoken, tx_id, ddo.asset_id, service, amount, cons_wallet.address
-    )
     return tx_id

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -211,10 +211,11 @@ def send_create_tx(web3, did, flags, data, account):
     return receipt
 
 
-def get_dataset_ddo_with_access_service(client, wallet) -> Asset:
+def get_dataset_ddo_with_access_service(client, wallet, timeout=3600) -> Asset:
     metadata = get_sample_ddo()["service"][0]["attributes"]
     metadata["main"]["files"][0]["checksum"] = str(uuid.uuid4())
     service = get_access_service(wallet.address, metadata)
+    service.main["timeout"] = timeout
     metadata["main"].pop("cost")
     return get_registered_ddo(client, wallet, metadata, service)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,10 +12,10 @@ from datetime import datetime
 from pathlib import Path
 
 import ipfshttpclient
-from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate, Metadata
 from eth_account import Account
 from eth_utils import add_0x_prefix, remove_0x_prefix
+from jsonsempai import magic  # noqa: F401
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.asset import Asset
 from ocean_provider.utils.basics import get_asset_from_metadatastore, get_web3
@@ -455,6 +455,6 @@ def send_order(client, ddo, datatoken, service, cons_wallet, expect_failure=Fals
     web3.eth.wait_for_transaction_receipt(tx_id)
 
     verify_order_tx(
-        web3, datatoken, tx_id, ddo.asset_id, service.index, amount, cons_wallet.address
+        web3, datatoken, tx_id, ddo.asset_id, service, amount, cons_wallet.address
     )
     return tx_id

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,8 +16,8 @@ from jsonsempai import magic  # noqa: F401
 from artifacts import DataTokenTemplate, Metadata
 from eth_account import Account
 from eth_utils import add_0x_prefix, remove_0x_prefix
-from web3.main import Web3
 from ocean_provider.constants import BaseURLs
+from ocean_provider.utils.asset import Asset
 from ocean_provider.utils.basics import (
     get_asset_from_metadatastore,
     get_datatoken_minter,
@@ -29,6 +29,7 @@ from ocean_provider.utils.encryption import do_encrypt
 from ocean_provider.utils.services import Service
 from ocean_provider.utils.util import checksum
 from tests.helpers.service_definitions import get_access_service
+from web3.main import Web3
 
 
 def get_gas_price(web3: Web3) -> int:
@@ -209,7 +210,7 @@ def send_create_tx(web3, did, flags, data, account):
     return receipt
 
 
-def get_dataset_ddo_with_access_service(client, wallet):
+def get_dataset_ddo_with_access_service(client, wallet) -> Asset:
     metadata = get_sample_ddo()["service"][0]["attributes"]
     metadata["main"]["files"][0]["checksum"] = str(uuid.uuid4())
     service = get_access_service(wallet.address, metadata)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,13 +18,14 @@ from eth_account import Account
 from eth_utils import add_0x_prefix, remove_0x_prefix
 from ocean_provider.constants import BaseURLs
 from ocean_provider.utils.asset import Asset
-from ocean_provider.utils.basics import (
-    get_asset_from_metadatastore,
-    get_datatoken_minter,
-    get_web3,
-)
+from ocean_provider.utils.basics import get_asset_from_metadatastore, get_web3
 from ocean_provider.utils.currency import to_wei
-from ocean_provider.utils.datatoken import get_tx_receipt, mint, verify_order_tx
+from ocean_provider.utils.datatoken import (
+    get_datatoken_minter,
+    get_tx_receipt,
+    mint,
+    verify_order_tx,
+)
 from ocean_provider.utils.encryption import do_encrypt
 from ocean_provider.utils.services import Service
 from ocean_provider.utils.util import checksum

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -452,6 +452,8 @@ def send_order(client, ddo, datatoken, service, cons_wallet, expect_failure=Fals
     }
     tx_id = contract_fn.transact(_transact).hex()
 
+    web3.eth.wait_for_transaction_receipt(tx_id)
+
     verify_order_tx(
         web3, datatoken, tx_id, ddo.asset_id, service.index, amount, cons_wallet.address
     )


### PR DESCRIPTION
Towards #442.

Changes proposed in this PR:

- Enforce order timeout when consuming an asset (download or c2d). If timeout == 0, order valid forever. else, reject request if current timestamp - order timestamp > timeout.
- Add `test_download_timeout`
- Ensure that errors in `validate_order_tx` result in 400 error responses (previously resulted in 503)
- Move `get_metadata_url` and `get_datatoken_minter` to fix circular import issues
- Add `service_timeout` argument to `verify_order_tx`
- Add `timeout` argument to the `get_dataset_ddo_with_access_service` test helper method
- Remove `verify_order_tx` from the `send_order` test helper method, unnecessary.