### PR TITLE
Add initialize compute timeout tests

### DIFF
--- a/ocean_provider/routes/consume.py
+++ b/ocean_provider/routes/consume.py
@@ -264,9 +264,9 @@ def download():
         _tx, _order_log, _ = validate_order(
             get_web3(), consumer_address, tx_id, asset, service
         )
-    except Exception:
+    except Exception as e:
         return error_response(
-            f"=Order with tx_id {tx_id} is not found on chain.",
+            f"=Order with tx_id {tx_id} could not be validated due to error: {e}",
             400,
             logger,
         )

--- a/ocean_provider/utils/datatoken.py
+++ b/ocean_provider/utils/datatoken.py
@@ -186,9 +186,12 @@ def verify_order_tx(
         )
 
     # Check if order expired. timeout == 0 means order is valid forever
+    timestamp_now = datetime.utcnow().timestamp()
+    timestamp_delta = timestamp_now - order_log.args.timestamp
+    logger.debug(
+        f"verify_order_tx: service timeout = {service.timeout}, timestamp delta = {timestamp_delta}"
+    )
     if service.timeout != 0:
-        timestamp_now = datetime.utcnow().timestamp()
-        timestamp_delta = timestamp_now - order_log.args.timestamp
         if timestamp_delta > service.timeout:
             raise ValueError(
                 f"The order has expired. \n"

--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -8,8 +8,8 @@ from ocean_provider.utils.services import ServiceType
 from ocean_provider.utils.util import msg_hash
 from tests.helpers.ddo_dict_builders import build_metadata_dict_type_algorithm
 from tests.test_helpers import (
-    get_registered_asset,
     get_first_service_by_type,
+    get_registered_asset,
     get_web3,
     mint_100_datatokens,
     start_order,
@@ -25,6 +25,7 @@ def build_and_send_ddo_with_compute_service(
     c2d_address=None,
     do_send=True,
     short_valid_until=True,
+    timeout=3600,
 ):
     web3 = get_web3()
     algo_metadata = build_metadata_dict_type_algorithm()
@@ -35,9 +36,12 @@ def build_and_send_ddo_with_compute_service(
             publisher_wallet,
             custom_metadata=algo_metadata,
             custom_service_endpoint="http://172.15.0.7:8030",
+            timeout=timeout,
         )
     else:
-        alg_ddo = get_registered_asset(publisher_wallet, custom_metadata=algo_metadata)
+        alg_ddo = get_registered_asset(
+            publisher_wallet, custom_metadata=algo_metadata, timeout=timeout
+        )
 
     # publish an algorithm asset (asset with metadata of type `algorithm`)
     service = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
@@ -48,7 +52,10 @@ def build_and_send_ddo_with_compute_service(
     # publish a dataset asset
     if asset_type == "allow_all_published":
         dataset_ddo_w_compute_service = get_registered_asset(
-            publisher_wallet, custom_services="vanilla_compute", custom_services_args=[]
+            publisher_wallet,
+            custom_services="vanilla_compute",
+            custom_services_args=[],
+            timeout=timeout,
         )
     else:
         dataset_ddo_w_compute_service = get_registered_asset(
@@ -66,6 +73,7 @@ def build_and_send_ddo_with_compute_service(
                     ),
                 }
             ],
+            timeout=timeout,
         )
 
     service = get_first_service_by_type(

--- a/tests/helpers/ddo_dict_builders.py
+++ b/tests/helpers/ddo_dict_builders.py
@@ -135,7 +135,12 @@ def build_credentials_dict() -> dict:
 
 
 def get_compute_service(
-    address, price, datatoken_address, trusted_algos=None, trusted_publishers=None
+    address,
+    price,
+    datatoken_address,
+    trusted_algos=None,
+    trusted_publishers=None,
+    timeout=3600,
 ):
     trusted_algos = [] if not trusted_algos else trusted_algos
     trusted_publishers = [] if not trusted_publishers else trusted_publishers
@@ -166,14 +171,14 @@ def get_compute_service(
         "name": "compute_1",
         "description": "compute_1",
         "datatokenAddress": datatoken_address,
-        "timeout": 3600,
+        "timeout": timeout,
         "serviceEndpoint": "http://172.15.0.4:8030/",
         "files": encrypted_files,
         "compute": compute_service_attributes,
     }
 
 
-def get_compute_service_no_rawalgo(address, price, datatoken_address):
+def get_compute_service_no_rawalgo(address, price, datatoken_address, timeout=3600):
     compute_service_attributes = {
         "namespace": "test",
         "allowRawAlgorithm": False,
@@ -201,7 +206,7 @@ def get_compute_service_no_rawalgo(address, price, datatoken_address):
         "name": "compute_1",
         "description": "compute_1",
         "datatokenAddress": datatoken_address,
-        "timeout": 3600,
+        "timeout": timeout,
         "serviceEndpoint": "http://172.15.0.4:8030/",
         "files": encrypted_files,
         "compute": compute_service_attributes,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -237,7 +237,11 @@ def get_registered_asset(
         ]
         if not custom_services
         else build_custom_services(
-            custom_services, from_wallet, datatoken_address, custom_services_args
+            custom_services,
+            from_wallet,
+            datatoken_address,
+            custom_services_args,
+            timeout,
         )
     )
 
@@ -443,7 +447,7 @@ def start_order(
 
 
 def build_custom_services(
-    services_type, from_wallet, datatoken_address, custom_services_args
+    services_type, from_wallet, datatoken_address, custom_services_args, timeout
 ):
     if services_type == "vanilla_compute":
         return [
@@ -452,11 +456,14 @@ def build_custom_services(
                 10,
                 datatoken_address,
                 trusted_algos=custom_services_args,
+                timeout=timeout,
             )
         ]
     if services_type == "norawalgo":
         return [
-            get_compute_service_no_rawalgo(from_wallet.address, 10, datatoken_address)
+            get_compute_service_no_rawalgo(
+                from_wallet.address, 10, datatoken_address, timeout
+            )
         ]
 
     return []

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -172,9 +172,7 @@ def test_initialize_compute_works(client, publisher_wallet, consumer_wallet):
 
 
 @pytest.mark.integration
-def test_initialize_compute_order_reused(
-    client, publisher_wallet, consumer_wallet, timeout
-):
+def test_initialize_compute_order_reused(client, publisher_wallet, consumer_wallet):
     """Call `initializeCompute` when there ARE reusable orders
 
     Enumerate all cases:

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -242,6 +242,7 @@ def test_initialize_compute_order_reused(client, publisher_wallet, consumer_wall
     assert "providerFee" not in response.json["datasets"][0]
     assert "providerFee" not in response.json["algorithm"]
 
+    # Sleep long enough for provider fees to expire
     time.sleep(30)
 
     payload["compute"]["validUntil"] = get_future_valid_until()
@@ -258,7 +259,8 @@ def test_initialize_compute_order_reused(client, publisher_wallet, consumer_wall
     assert "providerFee" in response.json["datasets"][0]
     assert "providerFee" in response.json["algorithm"]
 
-    time.sleep(30)
+    # Sleep long enough for orders to expire
+    time.sleep(60)
 
     # Case 3: expired orders, expired provider fees
     assert response.status_code == 200

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -260,7 +260,13 @@ def test_initialize_compute_order_reused(client, publisher_wallet, consumer_wall
     assert "providerFee" in response.json["algorithm"]
 
     # Sleep long enough for orders to expire
-    time.sleep(60)
+    time.sleep(30)
+
+    response = client.post(
+        BaseURLs.SERVICES_URL + "/initializeCompute",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
 
     # Case 3: expired orders, expired provider fees
     assert response.status_code == 200


### PR DESCRIPTION
Towards #442

Changes proposed in this PR:

- Test initialize compute, reuse order but the order is expired
- Improve debug log inside `verify_order_tx`
- Add `timeout` argument to `get_compute_service`, `get_compute_service_no_rawalgo`, and `build_custom_services`