### PR TITLE
Issue 1483 upload on publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ AQUARIUS_URL=https://aquarius.marketplace.dev-ocean.com
 PARITY_ADDRESS1=0x00bd138abd70e2f00903268f3db08f2d25677c9e
 PARITY_PASSWORD1=node0
 PARITY_KEYFILE1=tests/resources/consumer_key_file.json
+
+ESTUARY_API_KEY=123...

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,5 @@
+; Copyright Ocean Protocol contributors
+; SPDX-License-Identifier: Apache-2.0
 
 [eth-network]
 network = http://127.0.0.1:8545
@@ -18,3 +20,5 @@ provider.address = 0x00bd138abd70e2f00903268f3db08f2d25677c9e
 operator_service.url = https://operator-api.operator.dev-ocean.com/
 storage.path = ocean-provider.db
 downloads.path = consume-downloads
+uploads.path = publish-uploads
+upload.fee = 0

--- a/config.ini
+++ b/config.ini
@@ -22,3 +22,4 @@ storage.path = ocean-provider.db
 downloads.path = consume-downloads
 uploads.path = publish-uploads
 upload.fee = 0
+estuary.url = https://api.estuary.tech/

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -5,15 +5,14 @@
 """Config data."""
 
 import configparser
-from distutils.util import strtobool
 import json
 import logging
 import os
+from distutils.util import strtobool
 from pathlib import Path
 
-from jsonsempai import magic
 from addresses import address as contract_addresses
-
+from jsonsempai import magic
 
 NAME_NETWORK_URL = "network"
 NAME_ADDRESS_FILE = "address.file"
@@ -27,6 +26,7 @@ NAME_BLOCK_CONFIRMATIONS = "block_confirmations"
 NAME_AUTHORIZED_DECRYPTERS = "authorized_decrypters"
 NAME_UPLOADS_PATH = "uploads.path"
 NAME_ESTUARY_API_KEY = "estuary_api_key"
+NAME_ESTUARY_URL = "estuary.url"
 NAME_UPLOAD_FEE = "upload.fee"
 
 environ_names = {
@@ -177,6 +177,10 @@ class Config(configparser.ConfigParser):
     @property
     def estuary_api_key(self):
         return self.get("resources", NAME_ESTUARY_API_KEY, fallback=None)
+
+    @property
+    def estuary_url(self):
+        return self.get("resources", NAME_ESTUARY_URL, fallback=None)
 
     @property
     def upload_fee(self):

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -1,11 +1,8 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright Ocean Protocol contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 """Config data."""
-
-#  Copyright 2018 Ocean Protocol Foundation
-#  SPDX-License-Identifier: Apache-2.0
 
 import configparser
 from distutils.util import strtobool
@@ -28,6 +25,9 @@ NAME_ALLOW_NON_PUBLIC_IP = "allow_non_public_ip"
 NAME_STORAGE_PATH = "storage.path"
 NAME_BLOCK_CONFIRMATIONS = "block_confirmations"
 NAME_AUTHORIZED_DECRYPTERS = "authorized_decrypters"
+NAME_UPLOADS_PATH = "uploads.path"
+NAME_ESTUARY_API_KEY = "estuary_api_key"
+NAME_UPLOAD_FEE = "upload.fee"
 
 environ_names = {
     NAME_NETWORK_URL: [
@@ -60,6 +60,11 @@ environ_names = {
     NAME_AUTHORIZED_DECRYPTERS: [
         "AUTHORIZED_DECRYPTERS",
         "List of authorized decrypters",
+        "resources",
+    ],
+    NAME_ESTUARY_API_KEY: [
+        "ESTUARY_API_KEY",
+        "Estuary API key",
         "resources",
     ],
 }
@@ -164,3 +169,15 @@ class Config(configparser.ConfigParser):
     @property
     def block_confirmations(self):
         return int(self.get("eth-network", NAME_BLOCK_CONFIRMATIONS, fallback=0))
+
+    @property
+    def uploads_path(self):
+        return self.get("resources", NAME_UPLOADS_PATH, fallback=None)
+
+    @property
+    def estuary_api_key(self):
+        return self.get("resources", NAME_ESTUARY_API_KEY, fallback=None)
+
+    @property
+    def upload_fee(self):
+        return self.get("resources", NAME_UPLOAD_FEE, fallback=None)

--- a/ocean_provider/routes/__init__.py
+++ b/ocean_provider/routes/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Ocean Protocol Foundation
+# Copyright Ocean Protocol contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 """Unites routes from compute and consume files."""
@@ -12,3 +12,4 @@ from .compute import *  # isort:skip
 from .consume import *  # isort:skip
 from .encrypt import *  # isort:skip
 from .decrypt import *  # isort:skip
+from .upload import *  # isort:skip

--- a/ocean_provider/routes/upload.py
+++ b/ocean_provider/routes/upload.py
@@ -2,26 +2,19 @@
 # Copyright Ocean Protocol contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-import functools
-import json
 import logging
-import os
-import requests
-from datetime import datetime
 
-from flask import Response, jsonify, request
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
+from flask import jsonify, request
+
 from ocean_provider.requests_session import get_requests_session
 from ocean_provider.user_nonce import get_nonce, update_nonce
-from ocean_provider.utils.basics import (
-    get_config, 
-    get_provider_wallet, 
-    get_web3
-)
 from ocean_provider.utils.address import get_provider_fee_token
+from ocean_provider.utils.basics import get_config, get_provider_wallet, get_web3
 from ocean_provider.utils.error_responses import error_response
 from ocean_provider.utils.util import build_upload_response, get_request_data
+
 from . import services
 
 logger = logging.getLogger(__name__)
@@ -170,10 +163,10 @@ def upload_file():
         )
 
     try:
-        _tx = validate_upload_order(
+        __ = validate_upload_order(
             get_web3(), consumer_address, tx_id,
         )
-    except Exception as e:
+    except Exception:
         return error_response(
             f"=Order with tx_id {tx_id} could not be validated due to error: {e}",
             400,

--- a/ocean_provider/routes/upload.py
+++ b/ocean_provider/routes/upload.py
@@ -80,6 +80,10 @@ def validate_upload_order(web3, sender, tx_id):
         raise AssertionError(
             "`uploadOrder` transaction was from a different sender than the one specified.."
         )
+    if tx['value'] < get_config().upload_fee:
+        raise AssertionError(
+            "`uploadOrder` transaction does fully cover upload_fee.."
+        )
     cached_nonce = get_nonce(sender)
     if not cached_nonce or int(cached_nonce) < tx['nonce']:
         update_nonce(sender, tx['nonce'])

--- a/ocean_provider/routes/upload.py
+++ b/ocean_provider/routes/upload.py
@@ -1,0 +1,186 @@
+#
+# Copyright Ocean Protocol contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+import functools
+import json
+import logging
+import os
+import requests
+from datetime import datetime
+
+from flask import Response, jsonify, request
+from eth_keys import KeyAPI
+from eth_keys.backends import NativeECCBackend
+from ocean_provider.requests_session import get_requests_session
+from ocean_provider.user_nonce import get_nonce, update_nonce
+from ocean_provider.utils.basics import (
+    get_config, 
+    get_provider_wallet, 
+    get_web3
+)
+from ocean_provider.utils.address import get_provider_fee_token
+from ocean_provider.utils.error_responses import error_response
+from ocean_provider.utils.util import build_upload_response, get_request_data
+from . import services
+
+logger = logging.getLogger(__name__)
+keys = KeyAPI(NativeECCBackend)
+requests_session = get_requests_session()
+
+
+def get_provider_upload_fees(valid_until: int):
+    web3 = get_web3()
+    provider_wallet = get_provider_wallet()
+    provider_fee_address = provider_wallet.address
+    provider_fee_token = get_provider_fee_token(web3.chain_id)
+
+    provider_fee_amount = get_config().upload_fee
+    if provider_fee_amount:
+        provider_fee_amount = int(provider_fee_amount)
+    else:
+        provider_fee_amount = 0.01
+
+    message_hash = web3.solidityKeccak(
+        ["address", "address", "uint256", "uint256"],
+        [
+            web3.toChecksumAddress(provider_fee_address),
+            web3.toChecksumAddress(provider_fee_token),
+            provider_fee_amount,
+            valid_until,
+        ],
+    )
+
+    pk = keys.PrivateKey(provider_wallet.key)
+    prefix = "\x19Ethereum Signed Message:\n32"
+    signable_hash = web3.solidityKeccak(
+        ["bytes", "bytes"], [web3.toBytes(text=prefix), web3.toBytes(message_hash)]
+    )
+    signed = keys.ecdsa_sign(message_hash=signable_hash, private_key=pk)
+
+    provider_fee = {
+        "providerFeeAddress": provider_fee_address,
+        "providerFeeToken": provider_fee_token,
+        "providerFeeAmount": provider_fee_amount,
+        # make it compatible with last openzepellin https://github.com/OpenZeppelin/openzeppelin-contracts/pull/1622
+        "v": (signed.v + 27) if signed.v <= 1 else signed.v,
+        "r": web3.toHex(web3.toBytes(signed.r).rjust(32, b"\0")),
+        "s": web3.toHex(web3.toBytes(signed.s).rjust(32, b"\0")),
+        "validUntil": valid_until,
+    }
+    logger.debug(f"Returning provider_fees: {provider_fee}")
+    return provider_fee
+
+
+def validate_upload_order(web3, sender, tx_id):
+    logger.debug(
+        f"validate_order: tx_id={tx_id}, sender={sender}"
+    )
+    tx = web3.eth.get_transaction(tx_id)
+    tx_nonce = tx['nonce']
+    tx_sender = tx['from']
+    if tx_sender.lower() != sender.lower():
+        raise AssertionError(
+            "`uploadOrder` transaction was from a different sender than the one specified.."
+        )
+    cached_nonce = get_nonce(sender)
+    if not cached_nonce or int(cached_nonce) < tx_nonce:
+        update_nonce(sender, tx_nonce)
+        return tx
+    else:
+        raise AssertionError(
+            "Failed to get tx receipt for the `uploadOrder` transaction.."
+        )
+
+
+@services.route("/initializeUpload", methods=["GET"])
+def initializeUpload():
+    """Get fee that Provider will charge user for file upload.
+
+    ---
+    return:
+        json object as follows:
+        ```JSON
+        {
+            "providerFee": <object containing provider fees>
+        }
+        ```
+    """
+    data = get_request_data(request)
+    logger.info(f"initializeUpload called. arguments = {data}")
+
+    providerFee = get_provider_upload_fees(0)
+
+    response = jsonify(providerFee), 200
+    logger.info(f"initializeUpload response = {response}")
+
+    return response
+
+
+@services.route('/upload', methods=['POST'])
+def upload_file():
+    """Allows upload of asset data file.
+
+    ---
+    tags:
+      - services
+    consumes:
+      - application/json
+    parameters:
+      - name: consumerAddress
+        in: query
+        description: The consumer address.
+        required: true
+        type: string
+      - name: transferTxId
+        in: query
+        description: The tx
+        required: true
+        type: string
+      - name: file<i>
+        in: request.files
+        description: The multipart form data containing files.
+        required: true
+        type: string
+      - name: link<i>
+        in: request.files
+        description: The multipart form data containing (sample) files.
+        required: true
+        type: string
+    responses:
+      201:
+        description: Upload successful.
+      400:
+        description: One or more of the required attributes are missing or invalid.
+    returns:
+        CIDs of uploaded files.
+        Example: {"fileCids": ['0x123...'], "linkCids": []}
+    """
+    data = get_request_data(request)
+    logger.info(f"upload called. arguments = {data}")
+
+    try:
+        consumer_address = data.get("consumerAddress")
+        tx_id = data.get("transferTxId")
+    except Exception as e:
+        return error_response(
+            f"=Missing argument",
+            400,
+            logger,
+        )
+
+    try:
+        _tx = validate_upload_order(
+            get_web3(), consumer_address, tx_id,
+        )
+    except Exception as e:
+        return error_response(
+            f"=Order with tx_id {tx_id} could not be validated due to error: {e}",
+            400,
+            logger,
+        )
+
+    response = build_upload_response(request, requests_session)
+    logger.info(f"upload response = {response}")
+
+    return response

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -8,22 +8,23 @@ import logging
 import mimetypes
 import os
 from cgi import parse_header
-from urllib.parse import urljoin
 from typing import Tuple
-import werkzeug
+from urllib.parse import urljoin
 
 from eth_account.signers.local import LocalAccount
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
 from eth_typing.encoding import HexStr
+
+import werkzeug
 from flask import Response, jsonify
-from werkzeug.utils import secure_filename
-from ocean_provider.utils.basics import get_provider_wallet, get_config
+from ocean_provider.utils.basics import get_config, get_provider_wallet
 from ocean_provider.utils.encryption import do_decrypt
 from ocean_provider.utils.services import Service
-from ocean_provider.utils.url import is_safe_url, append_userdata, check_url_details
+from ocean_provider.utils.url import append_userdata, check_url_details, is_safe_url
 from web3 import Web3
 from web3.types import TxParams, TxReceipt
+from werkzeug.utils import secure_filename
 
 logger = logging.getLogger(__name__)
 keys = KeyAPI(NativeECCBackend)
@@ -113,7 +114,7 @@ def build_download_response(
 
 
 def upload_to_estuary(file_path, requests_session):
-    url = 'https://shuttle-4.estuary.tech/content/add'
+    url = get_config().estuary_url
     api_key = get_config().estuary_api_key
     with open(file_path, 'rb') as f:
         r = requests_session.post(url, files={'data': f}, headers={'Authorization': 'Bearer ' + api_key})


### PR DESCRIPTION
This is the backend part of the implementation for the spec described in #1483 (and #446).

Changes proposed in this PR:

- Add initializeUpload/ endpoint that returns the fee the Provider charges for upload service.
- Add upload/ endpoint for uploading files. This uploads to Estuary (which pins to IPFS and then establishes deals with Filecoin miners).
- The Provider must have access to an Estuary node. This could be an Estuary node run by the Provider runner or a remote Estuary node. The Estuary team expressed interest in supporting/subsidizing uploads for Ocean Market users.

Additional config variables:
- uploads_path (path to folder where files are temporarily stored before uploaded to external service, e.g., Estuary)
- estuary_api_key
- estuary_url
- upload_fee