### PR TITLE
fix validUntil usage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.18
+current_version = 1.0.19
 commit = True
 tag = True
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           repository: "oceanprotocol/barge"
           path: 'barge'
-          ref: v4
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}
         run: |

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -91,7 +91,7 @@ class Config(configparser.ConfigParser):
         self._logger = logging.getLogger("config")
 
         if filename:
-            self._logger.info(f"Config: loading config file {filename}")
+            self._logger.debug(f"Config: loading config file {filename}")
             with open(filename) as fp:
                 text = fp.read()
                 self.read_string(text)
@@ -100,7 +100,7 @@ class Config(configparser.ConfigParser):
                 self.read_string(kwargs["text"])
 
         if options_dict:
-            self._logger.info(f"Config: loading from dict {options_dict}")
+            self._logger.debug(f"Config: loading from dict {options_dict}")
             self.read_dict(options_dict)
 
         self._load_environ()
@@ -109,7 +109,7 @@ class Config(configparser.ConfigParser):
         for option_name, environ_item in environ_names.items():
             value = os.environ.get(environ_item[0])
             if value is not None:
-                self._logger.info(f"Config: setting environ {option_name} = {value}")
+                self._logger.debug(f"Config: setting environ {option_name} = {value}")
                 self.set(environ_item[2], option_name, value)
 
     @property

--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -122,7 +122,12 @@ def initializeCompute():
             400,
             logger,
         )
-
+    if datetime.utcnow().timestamp() >= valid_until:
+        return error_response(
+            "The validUntil value should be higher then current timpestamp.",
+            400,
+            logger,
+        )
     if not check_environment_exists(get_c2d_environments(), compute_env):
         return error_response("Compute environment does not exist", 400, logger)
 

--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -115,19 +115,14 @@ def initializeCompute():
 
     timestamp_ok = validate_timestamp(valid_until)
     valid_until = int(valid_until)
-
+    
     if not timestamp_ok:
         return error_response(
             "The validUntil value is not correct.",
             400,
             logger,
         )
-    if datetime.utcnow().timestamp() >= valid_until:
-        return error_response(
-            "The validUntil value should be higher then current timpestamp.",
-            400,
-            logger,
-        )
+    
     if not check_environment_exists(get_c2d_environments(), compute_env):
         return error_response("Compute environment does not exist", 400, logger)
 

--- a/ocean_provider/routes/compute.py
+++ b/ocean_provider/routes/compute.py
@@ -115,14 +115,14 @@ def initializeCompute():
 
     timestamp_ok = validate_timestamp(valid_until)
     valid_until = int(valid_until)
-    
+
     if not timestamp_ok:
         return error_response(
             "The validUntil value is not correct.",
             400,
             logger,
         )
-    
+
     if not check_environment_exists(get_c2d_environments(), compute_env):
         return error_response("Compute environment does not exist", 400, logger)
 

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 from datetime import datetime
+import logging
 import os
 from typing import Optional, Union
 
@@ -15,6 +16,7 @@ from requests_testadapter import Resp
 from web3 import WebsocketProvider
 from web3.main import Web3
 
+logger = logging.getLogger(__name__)
 
 def get_config(config_file: Optional[str] = None) -> Config:
     """
@@ -125,5 +127,6 @@ def validate_timestamp(value):
         now = datetime.utcnow()
 
         return valid_until > now
-    except Exception:
+    except Exception as e:
+        logger.error(f"Failed to validate timestamp {value}: {e}\n")
         return False

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -18,6 +18,7 @@ from web3.main import Web3
 
 logger = logging.getLogger(__name__)
 
+
 def get_config(config_file: Optional[str] = None) -> Config:
     """
     :return: Config instance

--- a/ocean_provider/utils/provider_fees.py
+++ b/ocean_provider/utils/provider_fees.py
@@ -131,7 +131,7 @@ def get_provider_fees_or_remote(
                 allow_expired_provider_fees=True,
             )
             log_valid_until = _provider_fees_log.args.validUntil
-            if datetime.utcnow().timestamp() <= log_valid_until:
+            if valid_until <= log_valid_until:
                 # already paid provider fees and both order and provider fees are still valid
                 return {"validOrder": dataset["transferTxId"]}
             else:

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     url="https://github.com/oceanprotocol/provider-py",
     # fmt: off
     # bumpversion needs single quotes
-    version='1.0.18',
+    version='1.0.19',
     # fmt: on
     zip_safe=False,
 )

--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -24,11 +24,13 @@ def build_and_send_ddo_with_compute_service(
     asset_type=None,
     c2d_address=None,
     do_send=True,
-    short_valid_until=True,
+    valid_until=None,
     timeout=3600,
     c2d_environment="ocean-compute",
 ):
     web3 = get_web3()
+    if valid_until is None:
+        valid_until = get_future_valid_until(short=True)
     algo_metadata = build_metadata_dict_type_algorithm()
     if c2d_address is None:
         c2d_address = consumer_wallet.address
@@ -95,7 +97,7 @@ def build_and_send_ddo_with_compute_service(
             dataset_ddo_w_compute_service.did,
             service,
             consumer_wallet.address,
-            get_future_valid_until(short=short_valid_until),
+            valid_until,
             c2d_environment,
         ),
         consumer_wallet,
@@ -112,7 +114,7 @@ def build_and_send_ddo_with_compute_service(
             alg_ddo.did,
             alg_service,
             consumer_wallet.address,
-            get_future_valid_until(short=short_valid_until),
+            valid_until,
             c2d_environment,
             force_zero=True,
         ),

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -161,7 +161,7 @@ def test_compute(client, publisher_wallet, consumer_wallet, free_c2d_env):
         False,
         None,
         free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -288,7 +288,7 @@ def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c
         True,
         None,
         free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -323,7 +323,7 @@ def test_compute_allow_all_published(
         False,
         "allow_all_published",
         free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -371,7 +371,7 @@ def test_compute_additional_input(
         False,
         None,
         free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -455,7 +455,7 @@ def test_compute_delete_job(
         False,
         None,
         free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -47,7 +47,7 @@ def test_compute_raw_algo(
     free_c2d_env,
 ):
     custom_services = "vanilla_compute" if allow_raw_algos else "norawalgo"
-
+    valid_until = get_future_valid_until()
     # publish a dataset asset
     dataset_ddo_w_compute_service = get_registered_asset(
         publisher_wallet, custom_services=custom_services, service_type="compute"
@@ -72,7 +72,7 @@ def test_compute_raw_algo(
             dataset_ddo_w_compute_service.did,
             sa,
             consumer_wallet.address,
-            get_future_valid_until(),
+            valid_until,
             free_c2d_env["id"],
         ),
         consumer_wallet,
@@ -110,14 +110,16 @@ def test_compute_raw_algo(
 def test_compute_specific_algo_dids(
     client, publisher_wallet, consumer_wallet, consumer_address, free_c2d_env
 ):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, _ = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
         consumer_wallet,
         False,
         None,
-        free_c2d_env["consumerAddress"],
-        free_c2d_env["id"],
+        c2d_address=free_c2d_env["consumerAddress"],
+        valid_until=valid_until,
+        c2d_environment=free_c2d_env["id"],
     )
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
     nonce, signature = get_compute_signature(client, consumer_wallet, ddo.did)
@@ -154,13 +156,15 @@ def test_compute_specific_algo_dids(
 
 @pytest.mark.integration
 def test_compute(client, publisher_wallet, consumer_wallet, free_c2d_env):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
         consumer_wallet,
         False,
         None,
-        free_c2d_env["consumerAddress"],
+        c2d_address=free_c2d_env["consumerAddress"],
+        valid_until=valid_until,
         c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
@@ -281,13 +285,15 @@ def test_compute(client, publisher_wallet, consumer_wallet, free_c2d_env):
 
 @pytest.mark.integration
 def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c2d_env):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
         consumer_wallet,
         True,
         None,
-        free_c2d_env["consumerAddress"],
+        c2d_address=free_c2d_env["consumerAddress"],
+        valid_until=valid_until,
         c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
@@ -316,13 +322,15 @@ def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c
 def test_compute_allow_all_published(
     client, publisher_wallet, consumer_wallet, free_c2d_env
 ):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
         consumer_wallet,
         False,
         "allow_all_published",
-        free_c2d_env["consumerAddress"],
+        c2d_address=free_c2d_env["consumerAddress"],
+        valid_until=valid_until,
         c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
@@ -371,9 +379,9 @@ def test_compute_additional_input(
         consumer_wallet,
         False,
         None,
-        free_c2d_env["consumerAddress"],
-        c2d_environment=free_c2d_env["id"],
+        c2d_address=free_c2d_env["consumerAddress"],
         valid_until=valid_until,
+        c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -450,13 +458,15 @@ def test_compute_additional_input(
 def test_compute_delete_job(
     client, publisher_wallet, consumer_wallet, consumer_address, free_c2d_env
 ):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
         consumer_wallet,
         False,
         None,
-        free_c2d_env["consumerAddress"],
+        c2d_address=free_c2d_env["consumerAddress"],
+        valid_until=valid_until,
         c2d_environment=free_c2d_env["id"],
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -364,6 +364,7 @@ def test_compute_allow_all_published(
 def test_compute_additional_input(
     client, publisher_wallet, consumer_wallet, monkeypatch, free_c2d_env
 ):
+    valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
@@ -372,6 +373,7 @@ def test_compute_additional_input(
         None,
         free_c2d_env["consumerAddress"],
         c2d_environment=free_c2d_env["id"],
+        valid_until=valid_until,
     )
     sa_compute = get_first_service_by_type(alg_ddo, ServiceType.ACCESS)
     sa = get_first_service_by_type(ddo, ServiceType.COMPUTE)
@@ -398,7 +400,7 @@ def test_compute_additional_input(
             ddo2.did,
             sa2,
             consumer_wallet.address,
-            get_future_valid_until(),
+            valid_until,
             free_c2d_env["id"],
             force_zero=True,
         ),

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -248,7 +248,8 @@ def test_initialize_compute_order_reused(
     Case 4:
         wrong tx id for dataset order
     """
-    # Order asset, valid for 60 seconds
+    # Order asset, valid for 30 seconds
+    valid_until = get_future_valid_until(short=True)
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
         client,
         publisher_wallet,
@@ -256,7 +257,7 @@ def test_initialize_compute_order_reused(
         True,
         None,
         free_c2d_env["consumerAddress"],
-        short_valid_until=True,
+        valid_until,
         timeout=60,
         c2d_environment=free_c2d_env["id"],
     )
@@ -280,7 +281,7 @@ def test_initialize_compute_order_reused(
         "consumerAddress": consumer_wallet.address,
         "compute": {
             "env": free_c2d_env["id"],
-            "validUntil": get_future_valid_until(short=True),
+            "validUntil": valid_until,
         },
     }
 
@@ -297,12 +298,10 @@ def test_initialize_compute_order_reused(
     assert "providerFee" not in response.json["datasets"][0]
     assert "providerFee" not in response.json["algorithm"]
 
-    # Update payload "validUntil" to 1 hour from now
-    payload["compute"]["validUntil"] = get_future_valid_until()
-
     # Sleep long enough for provider fees to expire
     timeout = time.time() + (30 * 4)
     while True:
+        payload["compute"]["validUntil"] = get_future_valid_until(short=True)+30
         response = client.post(
             BaseURLs.SERVICES_URL + "/initializeCompute",
             data=json.dumps(payload),
@@ -310,7 +309,7 @@ def test_initialize_compute_order_reused(
         )
         if "providerFee" in response.json["algorithm"] or time.time() > timeout:
             break
-        time.sleep(1)
+        time.sleep(5)
 
     # Case 2: valid orders, expired provider fees
     assert response.status_code == 200
@@ -320,7 +319,9 @@ def test_initialize_compute_order_reused(
     assert "providerFee" in response.json["algorithm"]
 
     # Sleep long enough for orders to expire
+    timeout = time.time() + (30 * 4)
     while True:
+        payload["compute"]["validUntil"] = get_future_valid_until(short=True)+30
         response = client.post(
             BaseURLs.SERVICES_URL + "/initializeCompute",
             data=json.dumps(payload),
@@ -328,7 +329,7 @@ def test_initialize_compute_order_reused(
         )
         if "validOrder" not in response.json["algorithm"] or time.time() > timeout:
             break
-        time.sleep(1)
+        time.sleep(5)
 
     # Case 3: expired orders, expired provider fees
     assert response.status_code == 200

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -309,7 +309,7 @@ def test_initialize_compute_order_reused(
         )
         if "providerFee" in response.json["algorithm"] or time.time() > timeout:
             break
-        time.sleep(5)
+        time.sleep(1)
 
     # Case 2: valid orders, expired provider fees
     assert response.status_code == 200
@@ -329,7 +329,7 @@ def test_initialize_compute_order_reused(
         )
         if "validOrder" not in response.json["algorithm"] or time.time() > timeout:
             break
-        time.sleep(5)
+        time.sleep(1)
 
     # Case 3: expired orders, expired provider fees
     assert response.status_code == 200

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -301,7 +301,7 @@ def test_initialize_compute_order_reused(
     # Sleep long enough for provider fees to expire
     timeout = time.time() + (30 * 4)
     while True:
-        payload["compute"]["validUntil"] = get_future_valid_until(short=True)+30
+        payload["compute"]["validUntil"] = get_future_valid_until(short=True) + 30
         response = client.post(
             BaseURLs.SERVICES_URL + "/initializeCompute",
             data=json.dumps(payload),
@@ -321,7 +321,7 @@ def test_initialize_compute_order_reused(
     # Sleep long enough for orders to expire
     timeout = time.time() + (30 * 4)
     while True:
-        payload["compute"]["validUntil"] = get_future_valid_until(short=True)+30
+        payload["compute"]["validUntil"] = get_future_valid_until(short=True) + 30
         response = client.post(
             BaseURLs.SERVICES_URL + "/initializeCompute",
             data=json.dumps(payload),


### PR DESCRIPTION
When a initializeCompute endpoint is called, we should always check if existing orders are valid until validUntil, and not the current timestamp


Main fix is one line in [ocean_provider/utils/provider_fees.py](https://github.com/oceanprotocol/provider/pull/487/files#diff-63b62246fbc8da10a0f1dfe53c633bada9fc1a20a65628433e7bcaa69d61fd57)
Rest is just test adjustments