### PR TITLE
add basic graphql support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |
-          bash -x start_ocean.sh --no-dashboard 2>&1 --with-rbac --with-provider2 --with-c2d > start_ocean.log &
+          bash -x start_ocean.sh --no-dashboard 2>&1 --with-rbac --with-provider2 --with-c2d --with-thegraph > start_ocean.log &
       - name: Install dependencies
         working-directory: ${{ github.workspace }}
         run: |

--- a/ocean_provider/file_types/file_types.py
+++ b/ocean_provider/file_types/file_types.py
@@ -62,3 +62,32 @@ class IpfsFile(EndUrlType, FilesType):
             raise Exception("No IPFS_GATEWAY defined, can not resolve ipfs hash.")
 
         return urljoin(os.getenv("IPFS_GATEWAY"), urljoin("ipfs/", self.hash))
+
+
+class GraphqlQuery(EndUrlType, FilesType):
+    @enforce_types
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        query=None,
+        headers: Optional[dict] = None,
+        userdata=None,
+    ) -> None:
+        self.url = url
+        self.userdata = {"query": query}
+        if userdata:
+            self.userdata["variables"] = userdata
+        self.method = 'post'
+        self.headers = headers if headers else {}
+        self.type = "graphql"
+        
+
+    @enforce_types
+    def validate_dict(self) -> Tuple[bool, Any]:
+        if not self.url:
+            return False, "missing graphql endpoint"
+        
+        return True, self
+
+    def get_download_url(self):
+        return self.url

--- a/ocean_provider/file_types/file_types.py
+++ b/ocean_provider/file_types/file_types.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 from typing import Any, Optional, Tuple
 from urllib.parse import urljoin
 
@@ -76,7 +77,10 @@ class GraphqlQuery(EndUrlType, FilesType):
         self.url = url
         self.userdata = {"query": query}
         if userdata:
-            self.userdata["variables"] = userdata
+            self.userdata["variables"] = (
+                userdata if isinstance(userdata, dict) else json.loads(userdata)
+            )
+
         self.method = "post"
         self.headers = headers if headers else {}
         self.type = "graphql"

--- a/ocean_provider/file_types/file_types.py
+++ b/ocean_provider/file_types/file_types.py
@@ -77,16 +77,15 @@ class GraphqlQuery(EndUrlType, FilesType):
         self.userdata = {"query": query}
         if userdata:
             self.userdata["variables"] = userdata
-        self.method = 'post'
+        self.method = "post"
         self.headers = headers if headers else {}
         self.type = "graphql"
-        
 
     @enforce_types
     def validate_dict(self) -> Tuple[bool, Any]:
         if not self.url:
             return False, "missing graphql endpoint"
-        
+
         return True, self
 
     def get_download_url(self):

--- a/ocean_provider/file_types/file_types_factory.py
+++ b/ocean_provider/file_types/file_types_factory.py
@@ -18,28 +18,28 @@ class FilesTypeFactory:
             return False, "cannot decrypt files for this service."
 
         try:
-            if file_obj["type"]=='url':
-                    instance = UrlFile(
-                        file_obj.get("url"),
-                        method=file_obj.get("method"),
-                        headers=file_obj.get("headers"),
-                        userdata=file_obj.get("userdata"),
-                    )
-            elif file_obj["type"]=='ipfs':
-                    instance = IpfsFile(
-                        file_obj.get("hash"),
-                        headers=file_obj.get("headers"),
-                        userdata=file_obj.get("userdata"),
-                    )
-            elif file_obj["type"]=='graphql':
-                    instance = GraphqlQuery(
-                        url = file_obj.get("url"),
-                        query = file_obj.get("query"),
-                        headers=file_obj.get("headers"),
-                        userdata=file_obj.get("userdata"),
-                    )
+            if file_obj["type"] == "url":
+                instance = UrlFile(
+                    file_obj.get("url"),
+                    method=file_obj.get("method"),
+                    headers=file_obj.get("headers"),
+                    userdata=file_obj.get("userdata"),
+                )
+            elif file_obj["type"] == "ipfs":
+                instance = IpfsFile(
+                    file_obj.get("hash"),
+                    headers=file_obj.get("headers"),
+                    userdata=file_obj.get("userdata"),
+                )
+            elif file_obj["type"] == "graphql":
+                instance = GraphqlQuery(
+                    url=file_obj.get("url"),
+                    query=file_obj.get("query"),
+                    headers=file_obj.get("headers"),
+                    userdata=file_obj.get("userdata"),
+                )
             else:
-                    return False, f'Unsupported type {file_obj["type"]}'
+                return False, f'Unsupported type {file_obj["type"]}'
         except TypeError:
             return False, "malformed file object."
 

--- a/ocean_provider/file_types/file_types_factory.py
+++ b/ocean_provider/file_types/file_types_factory.py
@@ -3,7 +3,7 @@ from typing import Any, Tuple
 
 from enforce_typing import enforce_types
 
-from ocean_provider.file_types.file_types import IpfsFile, UrlFile
+from ocean_provider.file_types.file_types import IpfsFile, UrlFile, GraphqlQuery
 
 logger = logging.getLogger(__name__)
 
@@ -17,27 +17,30 @@ class FilesTypeFactory:
         if not file_obj:
             return False, "cannot decrypt files for this service."
 
-        if "type" not in file_obj or file_obj["type"] not in ["ipfs", "url"]:
-            return (
-                False,
-                "malformed or unsupported type for service files.",
-            )
-
         try:
-            if file_obj["type"] == "url":
-                instance = UrlFile(
-                    file_obj.get("url"),
-                    method=file_obj.get("method"),
-                    headers=file_obj.get("headers"),
-                    userdata=file_obj.get("userdata"),
-                )
+            if file_obj["type"]=='url':
+                    instance = UrlFile(
+                        file_obj.get("url"),
+                        method=file_obj.get("method"),
+                        headers=file_obj.get("headers"),
+                        userdata=file_obj.get("userdata"),
+                    )
+            elif file_obj["type"]=='ipfs':
+                    instance = IpfsFile(
+                        file_obj.get("hash"),
+                        headers=file_obj.get("headers"),
+                        userdata=file_obj.get("userdata"),
+                    )
+            elif file_obj["type"]=='graphql':
+                    instance = GraphqlQuery(
+                        url = file_obj.get("url"),
+                        query = file_obj.get("query"),
+                        headers=file_obj.get("headers"),
+                        userdata=file_obj.get("userdata"),
+                    )
             else:
-                instance = IpfsFile(
-                    file_obj.get("hash"),
-                    headers=file_obj.get("headers"),
-                    userdata=file_obj.get("userdata"),
-                )
+                    return False, f'Unsupported type {file_obj["type"]}'
         except TypeError:
-            return False, "malformed or unsupported types."
+            return False, "malformed file object."
 
         return instance.validate_dict()

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -343,7 +343,7 @@ def test_validate_url_object():
 
     result, message = FilesTypeFactory.validate_and_create({"type": "not_ipfs_or_url"})
     assert result is False
-    assert message == "malformed or unsupported type for service files."
+    assert message == "Unsupported type not_ipfs_or_url"
 
     result, message = FilesTypeFactory.validate_and_create(
         {"type": "ipfs", "but_hash": "missing"}

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -355,14 +355,14 @@ def test_validate_url_object():
         {"type": "url", "url": "x", "headers": "not_a_dict"}
     )
     assert result is False
-    assert message == "alformed file object."
+    assert message == "malformed file object."
 
     result, message = FilesTypeFactory.validate_and_create(
         {"type": "url", "url": "x", "headers": '{"dict": "but_stringified"}'}
     )
     # we purposefully require a dictionary
     assert result is False
-    assert message == "alformed file object."
+    assert message == "malformed file object."
 
     result, message = FilesTypeFactory.validate_and_create(
         {"type": "url", "url": "x", "headers": {"dict": "dict_key"}}

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -355,14 +355,14 @@ def test_validate_url_object():
         {"type": "url", "url": "x", "headers": "not_a_dict"}
     )
     assert result is False
-    assert message == "malformed or unsupported types."
+    assert message == "alformed file object."
 
     result, message = FilesTypeFactory.validate_and_create(
         {"type": "url", "url": "x", "headers": '{"dict": "but_stringified"}'}
     )
     # we purposefully require a dictionary
     assert result is False
-    assert message == "malformed or unsupported types."
+    assert message == "alformed file object."
 
     result, message = FilesTypeFactory.validate_and_create(
         {"type": "url", "url": "x", "headers": {"dict": "dict_key"}}

--- a/tests/helpers/ddo_dict_builders.py
+++ b/tests/helpers/ddo_dict_builders.py
@@ -48,11 +48,12 @@ def _build_service_dict_untyped(
     service_endpoint: str,
     encrypted_files: HexStr,
     timeout: int,
+    userdata: dict = None,
 ) -> dict:
     """Build a service dict with required attributes only. See for details:
     https://github.com/oceanprotocol/docs/blob/v4main/content/concepts/did-ddo.md#services
     """
-    return {
+    service = {
         "id": str(uuid.uuid4()),
         "name": "name doesn't affect tests",
         "description": "decription doesn't affect tests",
@@ -61,6 +62,9 @@ def _build_service_dict_untyped(
         "files": encrypted_files,
         "timeout": timeout,
     }
+    if userdata:
+        service["consumerParameters"] = userdata
+    return service
 
 
 def build_service_dict_type_access(
@@ -68,6 +72,7 @@ def build_service_dict_type_access(
     service_endpoint: str,
     encrypted_files: HexStr,
     timeout: int = 3600,  # 1 hour
+    userdata: dict = None,
 ) -> dict:
     """Build an access service dict, used for testing"""
     access_service = _build_service_dict_untyped(

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -23,13 +23,11 @@ from tests.test_helpers import (
 
 
 @pytest.mark.integration
-def test_download_graphql_asset(
-    client, publisher_wallet, consumer_wallet, web3
-):
-    unencrypted_files_list=[
+def test_download_graphql_asset(client, publisher_wallet, consumer_wallet, web3):
+    unencrypted_files_list = [
         {
             "type": "graphql",
-            "url":"http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph",
+            "url": "http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph",
             "query": """
                     query{
                         nfts(orderBy: createdTimestamp,orderDirection:desc){
@@ -38,10 +36,12 @@ def test_download_graphql_asset(
                             createdTimestamp
                         }
                     }
-                    """
+                    """,
         }
     ]
-    asset = get_registered_asset(publisher_wallet, unencrypted_files_list = unencrypted_files_list)
+    asset = get_registered_asset(
+        publisher_wallet, unencrypted_files_list=unencrypted_files_list
+    )
     service = get_first_service_by_type(asset, ServiceType.ACCESS)
     mint_100_datatokens(
         web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
@@ -64,7 +64,7 @@ def test_download_graphql_asset(
     }
 
     download_endpoint = BaseURLs.SERVICES_URL + "/download"
-    
+
     # Consume using url index and signature (with nonce)
     nonce = str(datetime.utcnow().timestamp())
     _msg = f"{asset.did}{nonce}"
@@ -74,4 +74,3 @@ def test_download_graphql_asset(
         service.service_endpoint + download_endpoint, query_string=payload
     )
     assert response.status_code == 200, f"{response.data}"
-

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -4,6 +4,7 @@
 #
 import copy
 import time
+import json
 from datetime import datetime
 from unittest.mock import patch
 
@@ -74,3 +75,74 @@ def test_download_graphql_asset(client, publisher_wallet, consumer_wallet, web3)
         service.service_endpoint + download_endpoint, query_string=payload
     )
     assert response.status_code == 200, f"{response.data}"
+
+
+@pytest.mark.integration
+def test_download_graphql_asset_with_userdata(
+    client, publisher_wallet, consumer_wallet, web3
+):
+    unencrypted_files_list = [
+        {
+            "type": "graphql",
+            "url": "http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph",
+            "query": """
+                    query nfts($nftAddress: String){
+                        nfts(where: {id:$nftAddress},orderBy: createdTimestamp,orderDirection:desc){
+                            id
+                            symbol
+                            createdTimestamp
+                        }
+                    }
+                    """,
+        }
+    ]
+    asset = get_registered_asset(
+        publisher_wallet,
+        unencrypted_files_list=unencrypted_files_list,
+        custom_userdata=[
+            {
+                "name": "nftAddress",
+                "type": "text",
+                "label": "nftAddress",
+                "required": True,
+                "description": "Nft to search for",
+            }
+        ],
+    )
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+        "userdata": json.dumps({"nftAddress": asset.nftAddress.lower()}),
+    }
+
+    download_endpoint = BaseURLs.SERVICES_URL + "/download"
+    # Consume using url index and signature (with nonce)
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+    payload["signature"] = sign_message(_msg, consumer_wallet)
+    payload["nonce"] = nonce
+    response = client.get(
+        service.service_endpoint + download_endpoint, query_string=payload
+    )
+    assert response.status_code == 200, f"{response.data}"
+    reply = json.loads(response.data)
+    assert (
+        len(reply["data"]["nfts"]) == 1
+    )  # make sure our parametrized query works, otherwise we will get a lot of nfts
+    assert reply["data"]["nfts"][0]["id"] == asset.nftAddress.lower()

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import copy
+import time
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from ocean_provider.constants import BaseURLs
+from ocean_provider.utils.accounts import sign_message
+from ocean_provider.utils.provider_fees import get_provider_fees
+from ocean_provider.utils.services import ServiceType
+from tests.test_auth import create_token
+from tests.test_helpers import (
+    get_dataset_ddo_with_multiple_files,
+    get_first_service_by_type,
+    get_registered_asset,
+    mint_100_datatokens,
+    start_order,
+)
+
+
+@pytest.mark.integration
+def test_download_graphql_asset(
+    client, publisher_wallet, consumer_wallet, web3
+):
+    unencrypted_files_list=[
+        {
+            "type": "graphql",
+            "url":"http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph",
+            "query": """
+                    query{
+                        nfts(orderBy: createdTimestamp,orderDirection:desc){
+                            id
+                            symbol
+                            createdTimestamp
+                        }
+                    }
+                    """
+        }
+    ]
+    asset = get_registered_asset(publisher_wallet, unencrypted_files_list = unencrypted_files_list)
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+    }
+
+    download_endpoint = BaseURLs.SERVICES_URL + "/download"
+    
+    # Consume using url index and signature (with nonce)
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+    payload["signature"] = sign_message(_msg, consumer_wallet)
+    payload["nonce"] = nonce
+    response = client.get(
+        service.service_endpoint + download_endpoint, query_string=payload
+    )
+    assert response.status_code == 200, f"{response.data}"
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -171,6 +171,7 @@ def get_registered_asset(
     erc20_enterprise=False,
     service_type="access",
     timeout=3600,
+    custom_userdata=None,
 ):
     web3 = get_web3()
     data_nft_address = deploy_data_nft(
@@ -241,6 +242,7 @@ def get_registered_asset(
                 service_endpoint=service_endpoint,
                 encrypted_files=encrypted_files,
                 timeout=timeout,
+                userdata=custom_userdata,
             )
         ]
         if not custom_services


### PR DESCRIPTION
Closes #538 

Changes proposed in this PR:

- add 'graphql' storage type



How to use it:
- before running barge, do ' export PROVIDER_VERSION=graphql'
- when publishing your asset, using ocean.js/py , use something like:
```
[
        {
            "type": "graphql",
            "url": "http://172.15.0.15:8000/subgraphs/name/oceanprotocol/ocean-subgraph",
            "query": """
                    query{
                        nfts(orderBy: createdTimestamp,orderDirection:desc){
                            id
                            symbol
                            createdTimestamp
                        }
                    }
                    """,
        }
    ]
```
    instead of regular URL like:
```
    [
            {
                "url": "https://raw.githubusercontent.com/tbertinmahieux/MSongsDB/master/Tasks_Demos/CoverSongs/shs_dataset_test.txt",
                "type": "url",
                "method": "GET",
            }
        ]
```

