### PR TITLE
Feature/smartcontract data service

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.3
+current_version = 1.3.4
 commit = True
 tag = True
 

--- a/ocean_provider/file_types/file_types_factory.py
+++ b/ocean_provider/file_types/file_types_factory.py
@@ -3,7 +3,13 @@ from typing import Any, Tuple
 
 from enforce_typing import enforce_types
 
-from ocean_provider.file_types.file_types import ArweaveFile, IpfsFile, UrlFile, GraphqlQuery
+from ocean_provider.file_types.file_types import (
+    ArweaveFile,
+    IpfsFile,
+    UrlFile,
+    GraphqlQuery,
+)
+from ocean_provider.file_types.types.smartcontract import SmartContractCall
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +48,12 @@ class FilesTypeFactory:
                     url=file_obj.get("url"),
                     query=file_obj.get("query"),
                     headers=file_obj.get("headers"),
+                    userdata=file_obj.get("userdata"),
+                )
+            elif file_obj["type"] == "smartcontract":
+                instance = SmartContractCall(
+                    address=file_obj.get("address"),
+                    abi=file_obj.get("abi"),
                     userdata=file_obj.get("userdata"),
                 )
             else:

--- a/ocean_provider/file_types/types/smartcontract.py
+++ b/ocean_provider/file_types/types/smartcontract.py
@@ -67,17 +67,14 @@ class SmartContractCall(FilesType):
             address=web3.toChecksumAddress(self.address), abi=[self.abi]
         )
         function = contract.functions[self.abi.get("name")]
-        args = dict() if len(self.abi.get("inputs")) > 0 else None
+        args = dict()
         for input in self.abi.get("inputs"):
             args[input.get("name")] = self.userdata.get(input.get("name"))
             if input.get("type") == "address":
                 args[input.get("name")] = web3.toChecksumAddress(
                     args[input.get("name")]
                 )
-        if args:
-            result = function(**args).call()
-        else:
-            result = function().call()
+        result = function(**args).call()
         if isinstance(result, object):
             return json.dumps(result), "application/json"
         return result, "application/text"

--- a/ocean_provider/file_types/types/smartcontract.py
+++ b/ocean_provider/file_types/types/smartcontract.py
@@ -90,10 +90,7 @@ class SmartContractCall(FilesType):
     def check_details(self, with_checksum=False):
         try:
             result, type = self.fetch_smartcontract_call()
-            details = {
-                "contentLength": len(result) or "",
-                "contentType": type
-            }
+            details = {"contentLength": len(result) or "", "contentType": type}
             return True, details
         except Exception as e:
             return False, {}

--- a/ocean_provider/file_types/types/smartcontract.py
+++ b/ocean_provider/file_types/types/smartcontract.py
@@ -67,11 +67,7 @@ class SmartContractCall(FilesType):
             address=web3.toChecksumAddress(self.address), abi=[self.abi]
         )
         function = contract.functions[self.abi.get("name")]
-        if len(self.abi.get("inputs")) > 0:
-            args = dict()
-        else:
-            args = None
-
+        args = dict() if len(self.abi.get("inputs")) > 0 else None
         for input in self.abi.get("inputs"):
             args[input.get("name")] = self.userdata.get(input.get("name"))
             if input.get("type") == "address":
@@ -84,8 +80,7 @@ class SmartContractCall(FilesType):
             result = function().call()
         if isinstance(result, object):
             return json.dumps(result), "application/json"
-        else:
-            return result, "application/text"
+        return result, "application/text"
 
     def check_details(self, with_checksum=False):
         try:

--- a/ocean_provider/file_types/types/smartcontract.py
+++ b/ocean_provider/file_types/types/smartcontract.py
@@ -83,16 +83,16 @@ class SmartContractCall(FilesType):
         else:
             result = function().call()
         if isinstance(result, object):
-            return "application/json", json.dumps(result)
+            return json.dumps(result), "application/json"
         else:
-            return "application/text", result
+            return result, "application/text"
 
     def check_details(self, with_checksum=False):
         try:
-            result = self.fetch_smartcontract_call()
+            result, type = self.fetch_smartcontract_call()
             details = {
                 "contentLength": len(result) or "",
-                "contentType": "",
+                "contentType": type
             }
             return True, details
         except Exception as e:
@@ -104,7 +104,7 @@ class SmartContractCall(FilesType):
         validate_url=True,
     ):
         try:
-            result = self.fetch_smartcontract_call()
+            result, type = self.fetch_smartcontract_call()
             return Response(
                 result,
                 200,

--- a/ocean_provider/file_types/types/smartcontract.py
+++ b/ocean_provider/file_types/types/smartcontract.py
@@ -1,0 +1,113 @@
+import json
+import logging
+import os
+from typing import Any, Optional, Tuple
+from uuid import uuid4
+
+from enforce_typing import enforce_types
+from flask import Response
+from web3.main import Web3
+
+from ocean_provider.file_types.definitions import FilesType
+from ocean_provider.utils.basics import get_provider_wallet, get_web3
+
+logger = logging.getLogger(__name__)
+
+
+class SmartContractCall(FilesType):
+    @enforce_types
+    def __init__(
+        self,
+        address: Optional[str] = None,
+        abi: Optional[dict] = None,
+        userdata=None,
+    ) -> None:
+        self.address = address
+        self.type = "smartcontract"
+        self.abi = abi
+        self.userdata = None
+        if userdata:
+            self.userdata = (
+                userdata if isinstance(userdata, dict) else json.loads(userdata)
+            )
+
+    def get_download_url(self):
+        return ""
+
+    @enforce_types
+    def validate_dict(self) -> Tuple[bool, Any]:
+        if not self.address:
+            return False, "malformed smartcontract type, missing contract address"
+        # validate abi
+        inputs = self.abi.get("inputs")
+        type = self.abi.get("type")
+        if inputs is None or type != "function":
+            return False, "invalid abi"
+        if self.abi.get("stateMutability") != "view":
+            return False, "only view functions are allowed"
+        if not self.abi.get("name"):
+            return False, "missing name"
+
+        # check that all inputs have a match in userdata
+        if len(inputs) > 0 and self.userdata is None:
+            return False, f"Missing parameters"
+        for input in inputs:
+            value = self.userdata.get(input.get("name"))
+            if not value:
+                return False, f"Missing userparam: {input.name}"
+        return True, self
+
+    @enforce_types
+    def get_filename(self) -> str:
+        return uuid4().hex
+
+    def fetch_smartcontract_call(self):
+        web3 = get_web3()
+        contract = web3.eth.contract(
+            address=web3.toChecksumAddress(self.address), abi=[self.abi]
+        )
+        function = contract.functions[self.abi.get("name")]
+        if len(self.abi.get("inputs")) > 0:
+            args = dict()
+        else:
+            args = None
+
+        for input in self.abi.get("inputs"):
+            args[input.get("name")] = self.userdata.get(input.get("name"))
+            if input.get("type") == "address":
+                args[input.get("name")] = web3.toChecksumAddress(
+                    args[input.get("name")]
+                )
+        if args:
+            result = function(**args).call()
+        else:
+            result = function().call()
+        if isinstance(result, object):
+            return "application/json", json.dumps(result)
+        else:
+            return "application/text", result
+
+    def check_details(self, with_checksum=False):
+        try:
+            result = self.fetch_smartcontract_call()
+            details = {
+                "contentLength": len(result) or "",
+                "contentType": "",
+            }
+            return True, details
+        except Exception as e:
+            return False, {}
+
+    def build_download_response(
+        self,
+        request,
+        validate_url=True,
+    ):
+        try:
+            result = self.fetch_smartcontract_call()
+            return Response(
+                result,
+                200,
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to call contract")

--- a/ocean_provider/utils/test/test_util.py
+++ b/ocean_provider/utils/test/test_util.py
@@ -421,8 +421,7 @@ def test_build_download_response_arweave(monkeypatch):
 
     _, instance = FilesTypeFactory.validate_and_create(url_object)
     assert (
-        instance.get_download_url()
-        == f"https://arweave.net/{ARWEAVE_TRANSACTION_ID}"
+        instance.get_download_url() == f"https://arweave.net/{ARWEAVE_TRANSACTION_ID}"
     )
 
     response = instance.build_download_response(request)

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     url="https://github.com/oceanprotocol/provider-py",
     # fmt: off
     # bumpversion needs single quotes
-    version='1.3.3',
+    version='1.3.4',
     # fmt: on
     zip_safe=False,
 )

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -325,7 +325,6 @@ def test_compute_arweave(client, publisher_wallet, consumer_wallet, free_c2d_env
     assert response.status == "200 OK", f"start compute job failed: {response.data}"
 
 
-
 @pytest.mark.integration
 def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c2d_env):
     valid_until = get_future_valid_until()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -355,4 +355,7 @@ def test_download_arweave(client, publisher_wallet, consumer_wallet, web3):
         service.service_endpoint + download_endpoint, query_string=payload
     )
     assert response.status_code == 200, f"{response.data}"
-    assert response.data.decode("utf-8").partition('\n')[0] == "% 1. Title: Branin Function"
+    assert (
+        response.data.decode("utf-8").partition("\n")[0]
+        == "% 1. Title: Branin Function"
+    )

--- a/tests/test_smartcontract.py
+++ b/tests/test_smartcontract.py
@@ -1,0 +1,143 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import copy
+import json
+import time
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from ocean_provider.constants import BaseURLs
+from ocean_provider.utils.accounts import sign_message
+from ocean_provider.utils.address import get_contract_address
+from ocean_provider.utils.basics import get_config
+from ocean_provider.utils.provider_fees import get_provider_fees
+from ocean_provider.utils.services import ServiceType
+from tests.test_auth import create_token
+from tests.test_helpers import (
+    get_first_service_by_type,
+    get_registered_asset,
+    mint_100_datatokens,
+    start_order,
+)
+
+
+@pytest.mark.integration
+def test_download_smartcontract_asset(client, publisher_wallet, consumer_wallet, web3):
+    # publish asset, that calls Router's swapOceanFee function (does not need params)
+    router_address = get_contract_address(
+        get_config().address_file, "Router", web3.chain_id
+    )
+    abi = {
+        "inputs": [],
+        "name": "swapOceanFee",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+    unencrypted_files_list = [
+        {"type": "smartcontract", "address": router_address, "abi": abi}
+    ]
+    asset = get_registered_asset(
+        publisher_wallet, unencrypted_files_list=unencrypted_files_list
+    )
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+    }
+
+    download_endpoint = BaseURLs.SERVICES_URL + "/download"
+
+    # Consume using url index and signature (with nonce)
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+    payload["signature"] = sign_message(_msg, consumer_wallet)
+    payload["nonce"] = nonce
+    response = client.get(
+        service.service_endpoint + download_endpoint, query_string=payload
+    )
+    assert response.status_code == 200, f"{response.data}"
+
+
+@pytest.mark.integration
+def test_download_smartcontract_asset_with_userdata(
+    client, publisher_wallet, consumer_wallet, web3
+):
+    # publish asset, that calls Router's getOPCFee for a provided  baseToken userdata
+    router_address = get_contract_address(
+        get_config().address_file, "Router", web3.chain_id
+    )
+    abi = {
+        "inputs": [{"internalType": "address", "name": "baseToken", "type": "address"}],
+        "name": "getOPCFee",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    }
+    unencrypted_files_list = [
+        {"type": "smartcontract", "address": router_address, "abi": abi}
+    ]
+    asset = get_registered_asset(
+        publisher_wallet,
+        unencrypted_files_list=unencrypted_files_list,
+        custom_userdata=[
+            {
+                "name": "baseToken",
+                "type": "text",
+                "label": "baseToken",
+                "required": True,
+                "description": "baseToken to check for fee",
+            }
+        ],
+    )
+    service = get_first_service_by_type(asset, ServiceType.ACCESS)
+    mint_100_datatokens(
+        web3, service.datatoken_address, consumer_wallet.address, publisher_wallet
+    )
+    tx_id, _ = start_order(
+        web3,
+        service.datatoken_address,
+        consumer_wallet.address,
+        service.index,
+        get_provider_fees(asset.did, service, consumer_wallet.address, 0),
+        consumer_wallet,
+    )
+
+    payload = {
+        "documentId": asset.did,
+        "serviceId": service.id,
+        "consumerAddress": consumer_wallet.address,
+        "transferTxId": tx_id,
+        "fileIndex": 0,
+        "userdata": json.dumps({"baseToken": asset.nftAddress.lower()}),
+    }
+
+    download_endpoint = BaseURLs.SERVICES_URL + "/download"
+    # Consume using url index and signature (with nonce)
+    nonce = str(datetime.utcnow().timestamp())
+    _msg = f"{asset.did}{nonce}"
+    payload["signature"] = sign_message(_msg, consumer_wallet)
+    payload["nonce"] = nonce
+    response = client.get(
+        service.service_endpoint + download_endpoint, query_string=payload
+    )
+    assert response.status_code == 200, f"{response.data}"


### PR DESCRIPTION
Allow smartcontract view functions or public variables to be used as data source for any asset

# Simple call (no user input required) 
This will call swapOceanFee function on the router contract and use the output as source for a dataset
Example:

```
abi = {
        "inputs": [],
        "name": "swapOceanFee",
        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
        "stateMutability": "view",
        "type": "function",
    }
    unencrypted_files_list = [
        {"type": "smartcontract", "address": "0x8149276f275EEFAc110D74AFE8AFECEaeC7d1593", "abi": abi}
    ]
```

# Parametrized call
(requires user_parameters that matches abi input elements)


This will call getOPCFee function on the router contract and use the output as source for a dataset.
getOPCFee function requires one parameter, called baseToken, so we need to define that in list of custom_parameters, so consumer specifies a value
```
abi = {
        "inputs": [{"internalType": "address", "name": "baseToken", "type": "address"}],
        "name": "getOPCFee",
        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
        "stateMutability": "view",
        "type": "function",
    }
    unencrypted_files_list = [
        {"type": "smartcontract", "address": "0x8149276f275EEFAc110D74AFE8AFECEaeC7d1593", "abi": abi}
    ]
    asset = get_registered_asset(
        publisher_wallet,
        unencrypted_files_list=unencrypted_files_list,
        custom_userdata=[
            {
                "name": "baseToken",
                "type": "text",
                "label": "baseToken",
                "required": True,
                "description": "baseToken to check for fee",
            }
        ],
    )
```

FYI:
 - only stateMutability = view is supported (both functions and public smartcontract variables).  Provider cannot call functions that needs a transaction to be generated
 - only one element of abi is required  (function name is extracted from there), so you cannot paste the entire smartcontract abi
 - if there are inputs variables required by the function, then those variables must be defined as custom_parameters
