### PR TITLE
Fixes POA detection, remove env setting for POA.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Refer to the [API.md](API.md) file for endpoints and payloads.
 * `ARWEAVE_GATEWAY` defines arweave gateway for resolving arweave transaction ids.
 * `AUTHORIZED_DECRYPTERS` list of authorized addresses that are allowed to decrypt chain data. Use it to restrict access only to certain callers (e.g. custom Aquarius instance). Empty by default, meaning all decrypters are authorized.
 * `USE_CHAIN_PROOF` or `USE_HTTP_PROOF` set a mechanism for saving proof-of-download information. For any present true-ish value of `USE_CHAIN_PROOF`, the proof is sent on-chain. When defining `USE_HTTP_PROOF` the env var must configure a HTTP endpoint that accepts a POST request.
-* `IS_POA_NETWORK` define that the network used is POA style, requiring special middlewares
 
 
 #### Before you commit

--- a/ocean_provider/config.py
+++ b/ocean_provider/config.py
@@ -28,7 +28,6 @@ NAME_ALLOW_NON_PUBLIC_IP = "allow_non_public_ip"
 NAME_STORAGE_PATH = "storage.path"
 NAME_BLOCK_CONFIRMATIONS = "block_confirmations"
 NAME_AUTHORIZED_DECRYPTERS = "authorized_decrypters"
-NAME_IS_POA_NETWORK = "is_poa_network"
 
 environ_names = {
     NAME_NETWORK_URL: [
@@ -62,11 +61,6 @@ environ_names = {
         "AUTHORIZED_DECRYPTERS",
         "List of authorized decrypters",
         "resources",
-    ],
-    NAME_IS_POA_NETWORK: [
-        "IS_POA_NETWORK",
-        "Is POA network",
-        "eth-network",
     ],
 }
 
@@ -170,9 +164,3 @@ class Config(configparser.ConfigParser):
     @property
     def block_confirmations(self):
         return int(self.get("eth-network", NAME_BLOCK_CONFIRMATIONS, fallback=0))
-
-    @property
-    def is_poa_network(self):
-        return bool(
-            strtobool(self.get("eth-network", NAME_IS_POA_NETWORK, fallback="0"))
-        )

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -15,6 +15,7 @@ from ocean_provider.http_provider import CustomHTTPProvider
 from requests_testadapter import Resp
 from web3.middleware import geth_poa_middleware
 from web3 import WebsocketProvider
+from web3.exceptions import ExtraDataLengthError
 from web3.main import Web3
 
 logger = logging.getLogger(__name__)
@@ -74,7 +75,9 @@ def get_web3(network_url: Optional[str] = None, cached=True) -> Web3:
 
     web3 = Web3(provider=get_web3_connection_provider(network_url))
 
-    if get_config().is_poa_network:
+    try:
+        web3.eth.get_block("latest")
+    except ExtraDataLengthError:
         web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     web3.chain_id = web3.eth.chain_id

--- a/ocean_provider/utils/test/test_basics.py
+++ b/ocean_provider/utils/test/test_basics.py
@@ -49,19 +49,3 @@ def test_validate_timestamp():
 
     timestamp_past = (datetime.utcnow() - timedelta(hours=1)).timestamp()
     assert validate_timestamp(timestamp_past) is False
-
-
-@pytest.mark.unit
-def test_poa_network(monkeypatch):
-    web3 = get_web3(cached=False)
-    for middleware in web3.middleware_onion._queue:
-        break
-
-    assert not callable(middleware)
-
-    monkeypatch.setenv("IS_POA_NETWORK", "1")
-    web3 = get_web3(cached=False)
-    for middleware in web3.middleware_onion._queue:
-        break
-
-    assert callable(middleware)


### PR DESCRIPTION
Closes #556.

Tested with the same URL locally and reproduced easily. I concluded that using an env var is unreliable, so I changed the check to detect the specific ExtraDataLength error, just like in Aquarius where it properly works.