### PR TITLE
Bug/fix content length buggy headers

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.7
+current_version = 1.3.8
 commit = True
 tag = True
 

--- a/ocean_provider/file_types/definitions.py
+++ b/ocean_provider/file_types/definitions.py
@@ -137,7 +137,7 @@ class EndUrlType:
 
         # overwrite checksum flag if file is too large
         if with_checksum:
-            max_length = int(os.getenv("MAX_CHECKSUM_LENGTH", 0))
+            max_length = int(os.getenv("MAX_CHECKSUM_LENGTH", "0"))
             with func(**func_args) as r:
                 length = 0
                 try:

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     url="https://github.com/oceanprotocol/provider-py",
     # fmt: off
     # bumpversion needs single quotes
-    version='1.3.7',
+    version='1.3.8',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Closes #564 
Found some errors in provider, and we need to protect against some http servers which are not very compliant:

```

2022-11-09 21:37:05 | 2022-11-09 19:37:05 provider-684c4f4654-gz8r9 ocean_provider.run[15] INFO error: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again., payload: b''
-- | --
  |   | 2022-11-09 21:37:05 | 2022-11-09 19:37:05 provider-684c4f4654-gz8r9 ocean_provider.run[15] INFO incoming request = http, GET, 10.18.11.78, /access_tokens.db?
  |   | 2022-11-09 21:37:00 | ValueError: invalid literal for int() with base 10: '= 5242880'
  |   | 2022-11-09 21:37:00 | max_length = int(os.getenv("MAX_CHECKSUM_LENGTH", 0))
  |   | 2022-11-09 21:37:00 | File "/ocean-provider/ocean_provider/file_types/definitions.py", line 139, in _get_result_from_url
  |   | 2022-11-09 21:37:00 | result, extra_data = self._get_result_from_url(
  |   | 2022-11-09 21:37:00 | File "/ocean-provider/ocean_provider/file_types/definitions.py", line 68, in check_details
  |   | 2022-11-09 21:37:00 | valid, details = file_instance.check_details(with_checksum=with_checksum)
  |   | 2022-11-09 21:37:00 | File "/ocean-provider/ocean_provider/routes/consume.py", line 125, in fileinfo
  |   | 2022-11-09 21:37:00 | return fn(*args, **kwargs)
  |   | 2022-11-09 21:37:00 | File "/usr/local/lib/python3.8/dist-packages/flask_sieve/validator.py", line 81, in wrapper
  |   | 2022-11-09 21:37:00 | return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  |   | 2022-11-09 21:37:00 | File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1509, in dispatch_request
  |   | 2022-11-09 21:37:00 | rv = self.dispatch_request()
  |   | 2022-11-09 21:37:00 | File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1523, in full_dispatch_request
  |   | 2022-11-09 21:37:00 | Traceback (most recent call last):
  |   | 2022-11-09 21:37:00 | 2022-11-09 19:37:00 provider-684c4f4654-gz8r9 ocean_provider.run[15] ERROR error: invalid literal for int() with base 10: '= 52428', payload: b'{"type":"url","index":0,"url":"XXXXXX","method":"get"}'

```

added some default and extra checks