### PR TITLE
Increase timeout to wait more for assets from aqua.

### DIFF
--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -230,4 +230,4 @@ def get_compute_result(client, endpoint, params, raw_response=False):
 def get_future_valid_until(short=False):
     # return a timestamp for one hour in the future or 30s in the future if short
     time_diff = timedelta(hours=1) if not short else timedelta(seconds=30)
-    return int((datetime.utcnow() + time_diff).timestamp())
+    return int((datetime.now() + time_diff).timestamp())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,7 @@ def create_token(client, consumer_wallet, expiration=None):
     """Helper function to create a token using the API."""
     address = consumer_wallet.address
     if expiration is None:
-        expiration = int((datetime.utcnow() + timedelta(hours=1)).timestamp())
+        expiration = int((datetime.utcnow() + timedelta(hours=2)).timestamp())
 
     payload = {"address": address, "expiration": expiration}
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -386,14 +386,14 @@ def get_resource_path(dir_name, file_name):
         return pathlib.Path(os.path.join(os.path.sep, *base, file_name))
 
 
-def wait_for_asset(metadata_cache_url, did, timeout=30) -> Optional[Asset]:
+def wait_for_asset(metadata_cache_url, did, timeout=60) -> Optional[Asset]:
     start = time.time()
     ddo = None
     while not ddo:
         ddo = get_asset_from_metadatastore(metadata_cache_url, did)
 
         if not ddo:
-            time.sleep(0.2)
+            time.sleep(3)
 
         if time.time() - start > timeout:
             break


### PR DESCRIPTION
Fixes #589  .

Changes proposed in this PR:

- increased timeout and waiting time to retrieve assets from aquarius.
- modified time for nonces in test helpers.

Noticed the error [here](https://github.com/oceanprotocol/provider/actions/runs/3854634123/jobs/6568831886#step:9:29128)