### PR TITLE
restrict fileinfo for url to only GET method

### DIFF
--- a/ocean_provider/file_types/file_types.py
+++ b/ocean_provider/file_types/file_types.py
@@ -31,7 +31,7 @@ class UrlFile(EndUrlType, FilesType):
         if not self.url:
             return False, "malformed service files, missing required keys."
 
-        if self.method not in ["get", "post"]:
+        if self.method not in ["get"]:
             return False, f"Unsafe method {self.method}."
 
         return True, self


### PR DESCRIPTION
Fixes # 621.

Changes proposed in this PR:

- validation to restrict url type fileinfo to GET method only