### PR TITLE
Version headers

### DIFF
--- a/ocean_provider/http_provider.py
+++ b/ocean_provider/http_provider.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import lru
 import requests
+from ocean_provider.version import get_version
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 from web3 import HTTPProvider
@@ -42,6 +43,15 @@ class CustomHTTPProvider(HTTPProvider):
 
 def make_post_request(endpoint_uri: str, data: bytes, *args, **kwargs) -> bytes:
     kwargs.setdefault("timeout", 10)
+
+    version = get_version()
+    version_header = {"User-Agent": f"OceanProvider/{version}"}
+
+    if "headers" in kwargs:
+        kwargs["headers"].update(version_header)
+    else:
+        kwargs["headers"] = version_header
+
     session = _get_session(endpoint_uri)
     response = session.post(endpoint_uri, data=data, *args, **kwargs)
     response.raise_for_status()

--- a/ocean_provider/run.py
+++ b/ocean_provider/run.py
@@ -2,7 +2,6 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-import configparser
 import logging
 from http.client import responses
 
@@ -11,11 +10,12 @@ from flask_swagger import swagger
 from flask_swagger_ui import get_swaggerui_blueprint
 from ocean_provider.config import Config
 from ocean_provider.constants import BaseURLs, ConfigSections, Metadata
-from ocean_provider.utils.error_responses import strip_and_replace_urls
 from ocean_provider.myapp import app
 from ocean_provider.routes import services
 from ocean_provider.utils.basics import get_provider_wallet, get_web3
+from ocean_provider.utils.error_responses import strip_and_replace_urls
 from ocean_provider.utils.util import get_request_data
+from ocean_provider.version import get_version
 
 config = Config(filename=app.config["PROVIDER_CONFIG_FILE"])
 provider_url = config.get(ConfigSections.RESOURCES, "ocean_provider.url")
@@ -84,12 +84,6 @@ def get_provider_address():
     """Gets the provider wallet address."""
     provider_address = get_provider_wallet().address
     return provider_address
-
-
-def get_version():
-    conf = configparser.ConfigParser()
-    conf.read(".bumpversion.cfg")
-    return conf["bumpversion"]["current_version"]
 
 
 @app.route("/")

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -2,21 +2,20 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-from datetime import datetime
 import logging
 import os
+from datetime import datetime
 from typing import Optional, Union
 
-import requests
 from eth_account import Account
 from hexbytes import HexBytes
 from ocean_provider.config import Config
 from ocean_provider.http_provider import CustomHTTPProvider
-from requests_testadapter import Resp
-from web3.middleware import geth_poa_middleware
+from ocean_provider.version import get_version
 from web3 import WebsocketProvider
 from web3.exceptions import ExtraDataLengthError
 from web3.main import Web3
+from web3.middleware import geth_poa_middleware
 
 logger = logging.getLogger(__name__)
 
@@ -88,8 +87,11 @@ def get_web3(network_url: Optional[str] = None, cached=True) -> Web3:
 def get_web3_connection_provider(
     network_url: str,
 ) -> Union[CustomHTTPProvider, WebsocketProvider]:
+    version = get_version()
+    request_kwargs = {"headers": {"User-Agent": f"OceanProvider/{version}"}}
+
     if network_url.startswith("http"):
-        return CustomHTTPProvider(network_url)
+        return CustomHTTPProvider(network_url, request_kwargs=request_kwargs)
     elif network_url.startswith("ws"):
         return WebsocketProvider(network_url)
     else:

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -11,7 +11,6 @@ from eth_account import Account
 from hexbytes import HexBytes
 from ocean_provider.config import Config
 from ocean_provider.http_provider import CustomHTTPProvider
-from ocean_provider.version import get_version
 from web3 import WebsocketProvider
 from web3.exceptions import ExtraDataLengthError
 from web3.main import Web3
@@ -87,11 +86,8 @@ def get_web3(network_url: Optional[str] = None, cached=True) -> Web3:
 def get_web3_connection_provider(
     network_url: str,
 ) -> Union[CustomHTTPProvider, WebsocketProvider]:
-    version = get_version()
-    request_kwargs = {"headers": {"User-Agent": f"OceanProvider/{version}"}}
-
     if network_url.startswith("http"):
-        return CustomHTTPProvider(network_url, request_kwargs=request_kwargs)
+        return CustomHTTPProvider(network_url)
     elif network_url.startswith("ws"):
         return WebsocketProvider(network_url)
     else:

--- a/ocean_provider/version.py
+++ b/ocean_provider/version.py
@@ -1,0 +1,11 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import configparser
+
+
+def get_version():
+    conf = configparser.ConfigParser()
+    conf.read(".bumpversion.cfg")
+    return conf["bumpversion"]["current_version"]


### PR DESCRIPTION
As seen in https://github.com/oceanprotocol/aquarius/pull/1010. It might not have the same issues as Aquarius, since Aquarius has an upgraded web3.py which causes the issues. However, to be on the safe side, I added these changes here as well.