### PR TITLE
Correct header usage.

### DIFF
--- a/ocean_provider/http_provider.py
+++ b/ocean_provider/http_provider.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import lru
 import requests
+from ocean_provider.version import get_version
 from requests.adapters import HTTPAdapter
 from requests.sessions import Session
 from web3 import HTTPProvider
@@ -42,6 +43,15 @@ class CustomHTTPProvider(HTTPProvider):
 
 def make_post_request(endpoint_uri: str, data: bytes, *args, **kwargs) -> bytes:
     kwargs.setdefault("timeout", 10)
+
+    version = get_version()
+    version_header = {"User-Agent": f"OceanProvider/{version}"}
+
+    if "headers" in kwargs:
+        kwargs["headers"].update(version_header)
+    else:
+        kwargs["headers"] = version_header
+
     session = _get_session(endpoint_uri)
     response = session.post(endpoint_uri, data=data, *args, **kwargs)
     response.raise_for_status()

--- a/ocean_provider/utils/basics.py
+++ b/ocean_provider/utils/basics.py
@@ -13,7 +13,6 @@ from typing import Union
 from eth_account import Account
 from hexbytes import HexBytes
 from ocean_provider.http_provider import CustomHTTPProvider
-from ocean_provider.version import get_version
 from web3 import WebsocketProvider
 from web3.exceptions import ExtraDataLengthError
 from web3.main import Web3
@@ -150,11 +149,8 @@ def get_web3(chain_id, cached=True) -> Web3:
 def get_web3_connection_provider(
     network_url: str,
 ) -> Union[CustomHTTPProvider, WebsocketProvider]:
-    version = get_version()
-    request_kwargs = {"headers": {"User-Agent": f"OceanProvider/{version}"}}
-
     if network_url.startswith("http"):
-        return CustomHTTPProvider(network_url, request_kwargs=request_kwargs)
+        return CustomHTTPProvider(network_url)
     elif network_url.startswith("ws"):
         return WebsocketProvider(network_url)
     else:


### PR DESCRIPTION
As seen in https://github.com/oceanprotocol/aquarius/pull/1010. It might not have the same issues as Aquarius, since Aquarius has an upgraded web3.py which causes the issues. However, to be on the safe side, I added these changes here as well.