### PR TITLE
Reinstate old_signature check.

### DIFF
--- a/ocean_provider/utils/accounts.py
+++ b/ocean_provider/utils/accounts.py
@@ -31,28 +31,31 @@ def verify_signature(signer_address, signature, original_msg, nonce):
     :return: True if signature is valid, throws InvalidSignatureError otherwise
     """
     verify_nonce(signer_address, nonce)
-    # old_signature = signature
+
+    old_signature = signature
 
     message = f"{original_msg}{str(nonce)}"
     signature_bytes = Web3.toBytes(hexstr=signature)
     if signature_bytes[64] == 27:
         new_signature = b"".join([signature_bytes[0:64], b"\x00"])
+        bound = -2
     elif signature_bytes[64] == 28:
         new_signature = b"".join([signature_bytes[0:64], b"\x01"])
+        bound = -2
     else:
         new_signature = signature_bytes
+        bound = len(old_signature)
 
     signature = keys.Signature(signature_bytes=new_signature)
 
-    # TODO: restore this check
-    # if old_signature != str(signature):
-    #    msg = (
-    #        f"Invalid signature. Please check the nonce or documentId from the original message."
-    #        f" In case of compute endpoints, check also the job ID."
-    #        f" Got: {old_signature}, expected {signature}\n."
-    #    )
-    #    logger.error(msg)
-    #    raise InvalidSignatureError(msg)
+    if old_signature[0:bound] != str(signature)[0:bound]:
+        msg = (
+            f"Invalid signature. Please check the nonce or documentId from the original message."
+            f" In case of compute endpoints, check also the job ID."
+            f" Got: {old_signature}, expected {signature}\n."
+        )
+        logger.error(msg)
+        raise InvalidSignatureError(msg)
 
     message_hash = Web3.solidityKeccak(
         ["bytes"],


### PR DESCRIPTION
Closes #637. This is still not clear to me. Why do we have this check? We are the ones realigning the signature. What could we expect differently?