### PR TITLE
re-enable c2d tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Verify deployments
         run: |
           cat $HOME/.ocean/ocean-contracts/artifacts/address.json
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Test with pytest
         run: |
           coverage run --source ocean_provider -m pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,7 +49,6 @@ jobs:
           docker image rm node:18-alpine
           docker image rm buildpack-deps:buster
           docker image rm buildpack-deps:bullseye
-          docker image rm postgres:latest
           docker image rm debian:10
           docker image rm debian:11
           docker image rm moby/buildkit:latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |
-          bash -x start_ocean.sh --no-dashboard 2>&1 --with-rbac --with-provider2 --with-thegraph --skip-subgraph-deploy > start_ocean.log &
+          bash -x start_ocean.sh --no-dashboard 2>&1 --with-rbac --with-provider2 --with-thegraph --with-c2d --skip-subgraph-deploy > start_ocean.log &
       - name: Wait for contracts deployment and C2D cluster to be ready
         working-directory: ${{ github.workspace }}/barge
         run: |
           for i in $(seq 1 250); do
             sleep 10
-            [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" ] && break
+            [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" -a -f "$HOME/.ocean/ocean-c2d/ready" ] && break
             done
       - name: Verify deployments
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,8 +62,6 @@ jobs:
       - name: Verify deployments
         run: |
           cat $HOME/.ocean/ocean-contracts/artifacts/address.json
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Test with pytest
         run: |
           coverage run --source ocean_provider -m pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
+      - name: Delete default runner images
+        run: |
+          docker image rm node:14
+          docker image rm node:14-alpine
+          docker image rm node:16
+          docker image rm node:16-alpine
+          docker image rm node:18
+          docker image rm node:18-alpine
+          docker image rm buildpack-deps:buster
+          docker image rm buildpack-deps:bullseye
+          docker image rm postgres:latest
+          docker image rm debian:10
+          docker image rm debian:11
+          docker image rm moby/buildkit:latest
       - name: Wait for contracts deployment and C2D cluster to be ready
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,11 @@ jobs:
         working-directory: ${{ github.workspace }}/barge
         run: |
           bash -x start_ocean.sh --no-dashboard 2>&1 --with-rbac --with-provider2 --with-thegraph --with-c2d --skip-subgraph-deploy > start_ocean.log &
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
       - name: Wait for contracts deployment and C2D cluster to be ready
         working-directory: ${{ github.workspace }}/barge
         run: |
@@ -44,11 +49,6 @@ jobs:
       - name: Verify deployments
         run: |
           cat $HOME/.ocean/ocean-contracts/artifacts/address.json
-      - name: Install dependencies
-        working-directory: ${{ github.workspace }}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements_dev.txt
       - name: Test with pytest
         run: |
           coverage run --source ocean_provider -m pytest

--- a/ocean_provider/run.py
+++ b/ocean_provider/run.py
@@ -59,7 +59,7 @@ def get_services_endpoints():
             ),
         )
     )
-    for (key, value) in services_endpoints.items():
+    for key, value in services_endpoints.items():
         services_endpoints[key] = (
             list(
                 map(

--- a/ocean_provider/utils/accounts.py
+++ b/ocean_provider/utils/accounts.py
@@ -16,7 +16,7 @@ keys = KeyAPI(NativeECCBackend)
 
 def verify_nonce(signer_address, nonce):
     db_nonce = get_nonce(signer_address)
-    if db_nonce and _find_nonce_format(str(nonce)) < _find_nonce_format(str(db_nonce)):
+    if db_nonce and float(nonce) < float(db_nonce):
         msg = (
             f"Invalid signature expected nonce ({db_nonce}) > current nonce ({nonce})."
         )
@@ -112,10 +112,3 @@ def sign_message(message, wallet):
     signature = "0x" + r[2:] + s[2:] + v[2:]
 
     return signature
-
-
-def _find_nonce_format(nonce: str):
-    if "." in nonce and nonce[-1] != ".":
-        return float(nonce)
-    else:
-        return int(nonce)

--- a/ocean_provider/utils/accounts.py
+++ b/ocean_provider/utils/accounts.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import logging
+from _decimal import Decimal
 
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
@@ -16,7 +17,7 @@ keys = KeyAPI(NativeECCBackend)
 
 def verify_nonce(signer_address, nonce):
     db_nonce = get_nonce(signer_address)
-    if db_nonce and float(nonce) < float(db_nonce):
+    if db_nonce and Decimal(nonce) < Decimal(db_nonce):
         msg = (
             f"Invalid signature expected nonce ({db_nonce}) > current nonce ({nonce})."
         )

--- a/ocean_provider/utils/data_nft.py
+++ b/ocean_provider/utils/data_nft.py
@@ -47,7 +47,8 @@ def get_data_nft_contract(web3: Web3, address: Optional[str] = None) -> Contract
 
 def get_metadata(web3: Web3, address: str) -> Tuple[str, str, MetadataState, bool]:
     """Queries the ERC721 Template smart contract getMetaData call.
-    Returns metaDataDecryptorUrl, metaDataDecryptorAddress, metaDataState, and hasMetaData"""
+    Returns metaDataDecryptorUrl, metaDataDecryptorAddress, metaDataState, and hasMetaData
+    """
     data_nft_contract = get_data_nft_contract(web3, address)
 
     return data_nft_contract.caller.getMetaData()

--- a/ocean_provider/utils/test/test_accounts.py
+++ b/ocean_provider/utils/test/test_accounts.py
@@ -20,14 +20,6 @@ def test_get_private_key(publisher_wallet):
 
 
 @pytest.mark.unit
-def test_find_nonce_format():
-    nonce = "1"
-    assert isinstance(_find_nonce_format(nonce), int)
-    nonce = "1.1"
-    assert isinstance(_find_nonce_format(nonce), float)
-
-
-@pytest.mark.unit
 def test_verify_signature(consumer_wallet, publisher_wallet):
     nonce = build_nonce(consumer_wallet.address)
     did = "did:op:test"

--- a/ocean_provider/utils/test/test_accounts.py
+++ b/ocean_provider/utils/test/test_accounts.py
@@ -6,7 +6,6 @@ from ocean_provider.utils.accounts import (
     get_private_key,
     sign_message,
     verify_signature,
-    _find_nonce_format,
 )
 from tests.helpers.nonce import build_nonce
 

--- a/ocean_provider/utils/test/test_compute.py
+++ b/ocean_provider/utils/test/test_compute.py
@@ -14,7 +14,6 @@ test_logger = logging.getLogger(__name__)
 
 
 @pytest.mark.unit
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_get_compute_endpoint(monkeypatch):
     monkeypatch.setenv("OPERATOR_SERVICE_URL", "http://with-slash.com/")
     assert get_compute_endpoint() == "http://with-slash.com/api/v1/operator/compute"

--- a/ocean_provider/utils/test/test_provider_fees.py
+++ b/ocean_provider/utils/test/test_provider_fees.py
@@ -14,7 +14,6 @@ from tests.test_helpers import (
 
 
 @pytest.mark.unit
-@pytest.mark.skip("C2D connection needs fixing.")
 @freeze_time("Feb 11th, 2012 00:00")
 def test_get_provider_fee_amount(web3, publisher_wallet):
     valid_until = get_future_valid_until()

--- a/ocean_provider/validation/test/test_algo_validation.py
+++ b/ocean_provider/validation/test/test_algo_validation.py
@@ -21,7 +21,6 @@ provider_fees_event.args.providerFeeAmount = 0
 this_is_a_gist = "https://gist.githubusercontent.com/calina-c/5e8c965962bc0240eab516cb7a180670/raw/6e6cd245c039a9aac0a488857c6927d39eaafe4d/sprintf-py-conversions"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -64,7 +63,6 @@ def test_passes_algo_ddo(provider_wallet, consumer_address, web3):
         assert validator.validate() is True
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -105,7 +103,6 @@ def test_passes_raw(provider_wallet, consumer_address, web3):
         assert validator.validate() is True
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -152,7 +149,6 @@ def test_fails_not_an_algo(provider_wallet, consumer_address, web3):
         assert validator.message == "not_algo"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -253,7 +249,6 @@ def test_fails_meta_issues(provider_wallet, consumer_address, web3):
         assert validator.message == "checksum_prefix"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -386,7 +381,6 @@ def test_additional_datasets(provider_wallet, consumer_address, web3):
         assert validator.message == "not_found"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -444,7 +438,6 @@ def test_service_not_compute(provider_wallet, consumer_address, web3):
             assert validator.message == "service_not_access_compute"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -543,7 +536,6 @@ def test_fails_trusted(provider_wallet, consumer_address, web3):
         assert validator.message == "not_trusted_algo_publisher"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -568,7 +560,6 @@ def test_fails_no_asset_url(provider_wallet, consumer_address, web3):
         assert validator.message == "compute_services_not_in_same_provider"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch("ocean_provider.validation.algo.validate_order", side_effect=Exception("mock"))
@@ -593,7 +584,6 @@ def test_fails_validate_order(provider_wallet, consumer_address, web3):
         assert validator.message == "order_invalid"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -621,7 +611,6 @@ def test_fails_no_service_id(provider_wallet, consumer_address, web3):
         assert validator.message == "missing"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -668,7 +657,6 @@ def test_fails_invalid_algorithm_dict(provider_wallet, consumer_address, web3):
         assert validator.message == "did_not_found"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -722,7 +710,6 @@ def test_fails_algorithm_in_use(provider_wallet, consumer_address, web3):
             assert validator.message == "in_use_or_not_on_chain"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -780,7 +767,6 @@ def test_fail_wrong_algo_type(provider_wallet, consumer_address, web3):
             assert validator.message == "main_service_compute"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -832,7 +818,6 @@ def test_fail_allow_raw_false(provider_wallet, consumer_address, web3):
         assert validator.message == "no_raw_algo_allowed"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -892,7 +877,6 @@ def test_success_multiple_services_types(provider_wallet, consumer_address, web3
             assert validator.validate() is True
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -939,7 +923,6 @@ def test_fail_missing_algo_meta_documentId(provider_wallet, consumer_address, we
             assert validator.message == "missing_meta_documentId"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(
@@ -985,7 +968,6 @@ def test_fee_amount_not_paid(provider_wallet, consumer_address, web3):
             assert validator.message == "fees_not_paid"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
 @patch("ocean_provider.validation.algo.check_asset_consumable", return_value=(True, ""))
 @patch(

--- a/tests/helpers/compute_helpers.py
+++ b/tests/helpers/compute_helpers.py
@@ -8,7 +8,7 @@ from ocean_provider.utils.services import ServiceType
 from ocean_provider.utils.util import msg_hash
 from tests.helpers.constants import ARWEAVE_TRANSACTION_ID
 from tests.helpers.ddo_dict_builders import build_metadata_dict_type_algorithm
-from tests.helpers.nonce import build_nonce
+from tests.helpers.nonce import build_nonce, build_nonce_for_compute
 from tests.test_helpers import (
     get_first_service_by_type,
     get_registered_asset,
@@ -155,7 +155,7 @@ def build_and_send_ddo_with_compute_service(
 
 
 def get_compute_signature(client, consumer_wallet, did, job_id=None):
-    nonce = build_nonce(consumer_wallet.address)
+    nonce = build_nonce_for_compute()
 
     # prepare consumer signature on did
     if job_id:

--- a/tests/helpers/nonce.py
+++ b/tests/helpers/nonce.py
@@ -1,3 +1,5 @@
+import time
+
 from ocean_provider.user_nonce import get_nonce, update_nonce
 
 
@@ -11,3 +13,7 @@ def build_nonce(address) -> int:
 
     update_nonce(address, 1)
     return 1
+
+
+def build_nonce_for_compute() -> int:
+    return time.time_ns()

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -33,18 +33,14 @@ from tests.test_auth import create_token
 from tests.test_helpers import get_first_service_by_type, get_ocean_token_address
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_rejected(client, monkeypatch):
     monkeypatch.delenv("OPERATOR_SERVICE_URL")
     response = post_to_compute(client, {})
     assert response.status_code == 404
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.parametrize("allow_raw_algos", [True, False])
 def test_compute_raw_algo(
     client,
@@ -120,9 +116,7 @@ def test_compute_raw_algo(
         assert "no_raw_algo_allowed" == response.json["error"]["dataset"]
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_specific_algo_dids(
     client, publisher_wallet, consumer_wallet, consumer_address, free_c2d_env
 ):
@@ -167,9 +161,7 @@ def test_compute_specific_algo_dids(
     assert response.json["error"]["dataset"] == "not_trusted_algo"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute(client, publisher_wallet, consumer_wallet, free_c2d_env):
     valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
@@ -295,9 +287,7 @@ def test_compute(client, publisher_wallet, consumer_wallet, free_c2d_env):
     assert result_data is not None, "We should have a result"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_arweave(client, publisher_wallet, consumer_wallet, free_c2d_env):
     valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
@@ -334,9 +324,7 @@ def test_compute_arweave(client, publisher_wallet, consumer_wallet, free_c2d_env
     assert response.status == "200 OK", f"start compute job failed: {response.data}"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c2d_env):
     valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(
@@ -371,9 +359,7 @@ def test_compute_diff_provider(client, publisher_wallet, consumer_wallet, free_c
     assert response.status == "200 OK", f"start compute job failed: {response.data}"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_allow_all_published(
     client, publisher_wallet, consumer_wallet, free_c2d_env
 ):
@@ -420,9 +406,7 @@ def test_compute_allow_all_published(
     assert response.status == "200 OK"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_additional_input(
     client, publisher_wallet, consumer_wallet, monkeypatch, free_c2d_env, web3
 ):
@@ -507,9 +491,7 @@ def test_compute_additional_input(
     assert response.status == "200 OK", f"start compute job failed: {response.data}"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_delete_job(
     client, publisher_wallet, consumer_wallet, consumer_address, free_c2d_env
 ):
@@ -574,9 +556,7 @@ def test_compute_delete_job(
     assert response.status == "200 OK", f"delete compute job failed: {response.data}"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.unit
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_environments():
     environments = get_c2d_environments()
 
@@ -585,9 +565,7 @@ def test_compute_environments():
             assert env["id"] == "ocean-compute"
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_paid_env(
     client, publisher_wallet, consumer_wallet, paid_c2d_env, web3
 ):
@@ -636,9 +614,7 @@ def test_compute_paid_env(
     _ = job_info.get("jobId", "")
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
-@pytest.mark.skip("C2D connection needs fixing.")
 def test_compute_auth_token(client, publisher_wallet, consumer_wallet, free_c2d_env):
     valid_until = get_future_valid_until()
     ddo, tx_id, alg_ddo, alg_tx_id = build_and_send_ddo_with_compute_service(

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -376,7 +376,7 @@ def set_nft_state(nft_address, nft_state, wallet):
 def get_dataset_ddo_disabled(client, wallet):
     asset = get_registered_asset(wallet)
     did = asset.did
-    set_nft_state(asset.nft["address"], 4, wallet)
+    set_nft_state(asset.nft["address"], 1, wallet)
     aqua_root = "http://172.15.0.5:5000"
     time.sleep(5)
     return asset, wait_for_asset(aqua_root, did)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -376,7 +376,7 @@ def set_nft_state(nft_address, nft_state, wallet):
 def get_dataset_ddo_disabled(client, wallet):
     asset = get_registered_asset(wallet)
     did = asset.did
-    set_nft_state(asset.nft["address"], 1, wallet)
+    set_nft_state(asset.nft["address"], 4, wallet)
     aqua_root = "http://172.15.0.5:5000"
     time.sleep(5)
     return asset, wait_for_asset(aqua_root, did)

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -178,7 +178,6 @@ def test_can_not_initialize_compute_service_with_simple_initialize(
     )
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
 def test_initialize_compute_works(
     client, publisher_wallet, consumer_wallet, free_c2d_env
@@ -232,7 +231,6 @@ def test_initialize_compute_works(
     assert "validOrder" not in response.json["algorithm"]
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
 def test_initialize_compute_order_reused(
     client, publisher_wallet, consumer_wallet, free_c2d_env
@@ -361,7 +359,6 @@ def test_initialize_compute_order_reused(
     assert "providerFee" in response.json["datasets"][0].keys()
 
 
-@pytest.mark.skip("C2D connection needs fixing.")
 @pytest.mark.integration
 def test_initialize_compute_paid_env(
     client, publisher_wallet, consumer_wallet, paid_c2d_env

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -77,7 +77,7 @@ def test_initialize_on_disabled_asset(client, publisher_wallet, consumer_wallet,
         client, asset.did, service, consumer_wallet, raw_response=True
     )
     assert "error" in response.json
-    assert response.json["error"] == "Asset malformed or disabled."
+    assert response.json["error"] == "Asset is not consumable."
 
 
 @pytest.mark.integration

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -103,16 +103,6 @@ def test_get_nonce(client, publisher_wallet):
 
 
 def test_timestamp_format_nonce(client, ganache_wallet, consumer_wallet, web3):
-    address = ganache_wallet.address
-    # Insert in db timestamp format nonce for this particular account
-    timestamp = str(datetime.datetime.utcnow().timestamp() * 1000)
-    update_nonce(address, timestamp)
-    nonce = get_nonce(address)
-    assert timestamp == nonce
-
-    # Cast to int
-    nonce = int(float(nonce)) + 1
-
     # Send download request with the new nonce
     asset = get_registered_asset(ganache_wallet)
     service = get_first_service_by_type(asset, ServiceType.ACCESS)
@@ -127,6 +117,15 @@ def test_timestamp_format_nonce(client, ganache_wallet, consumer_wallet, web3):
         get_provider_fees(asset, service, consumer_wallet.address, 0),
         consumer_wallet,
     )
+
+    # Insert in db timestamp format nonce for this particular account
+    timestamp = str(datetime.datetime.utcnow().timestamp() * 1000)
+    update_nonce(consumer_wallet.address, timestamp)
+    nonce = get_nonce(consumer_wallet.address)
+    assert timestamp == nonce
+
+    # Cast to int
+    nonce = int(float(nonce)) + 1
 
     payload = {
         "documentId": asset.did,


### PR DESCRIPTION

Changes proposed in this PR:

- 

Good news is that almost all test are passing locally
```
(provider) alx@ubuntu:/ocean/provider$ coverage run --source ocean_provider -m pytest
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.0.0
rootdir: /ocean/provider, configfile: pytest.ini
plugins: env-0.6.2, web3-5.25.0
collected 136 items                                                            

ocean_provider/test/test_user_nonce.py ...                               [  2%]
ocean_provider/utils/test/test_accounts.py ...                           [  4%]
ocean_provider/utils/test/test_address.py ...                            [  6%]
ocean_provider/utils/test/test_basics.py ........                        [ 12%]
ocean_provider/utils/test/test_compute.py .                              [ 13%]
ocean_provider/utils/test/test_credentials.py ...                        [ 15%]
ocean_provider/utils/test/test_currency.py ..                            [ 16%]
ocean_provider/utils/test/test_encyption.py ...                          [ 19%]
ocean_provider/utils/test/test_error_responses.py ..                     [ 20%]
ocean_provider/utils/test/test_provider_fees.py .                        [ 21%]
ocean_provider/utils/test/test_url.py ....                               [ 24%]
ocean_provider/utils/test/test_util.py ........                          [ 30%]
ocean_provider/validation/test/test_algo_validation.py ................. [ 42%]
.                                                                        [ 43%]
tests/test_RBAC.py .......                                               [ 48%]
tests/test_auth.py ....                                                  [ 51%]
tests/test_compute.py ............F                                      [ 61%]
tests/test_download.py .............                                     [ 70%]
tests/test_encryption.py .....                                           [ 74%]
tests/test_fileinfo.py ........                                          [ 80%]
tests/test_graphql.py ..                                                 [ 81%]
tests/test_initialize.py ..F.......                                      [ 88%]
tests/test_proof.py ...                                                  [ 91%]
tests/test_routes.py .........                                           [ 97%]
tests/test_smartcontract.py ...                                          [100%]

``` 