### PR TITLE
add more details for malformed addrs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,24 +41,14 @@ jobs:
           pip install -r requirements_dev.txt
       - name: Delete default runner images
         run: |
-          docker image rm node:14
-          docker image rm node:14-alpine
           docker image rm node:16
           docker image rm node:16-alpine
           docker image rm node:18
           docker image rm node:18-alpine
           docker image rm node:20
-          docker image rm node:20-alpine
-          docker image rm buildpack-deps:buster
-          docker image rm buildpack-deps:bullseye
           docker image rm debian:10
           docker image rm debian:11
           docker image rm moby/buildkit:latest
-          docker image rm alpine:3.16
-          docker image rm alpine:3.17
-          docker image rm alpine:3.18
-          docker image rm ubuntu:18.04
-          docker image rm ubuntu:20.04
       - name: Wait for contracts deployment and C2D cluster to be ready
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -55,20 +55,29 @@ def get_service_files_list(
                     f"Provider {network_name}: Key {key} not found in files."
                 )
 
-        if Web3.toChecksumAddress(
-            files_json["datatokenAddress"]
-        ) != Web3.toChecksumAddress(service.datatoken_address):
-            raise Exception(
-                f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
-            )
+        try:
+            if Web3.toChecksumAddress(
+                files_json["datatokenAddress"]
+            ) != Web3.toChecksumAddress(service.datatoken_address):
+                raise Exception(
+                    f"Provider {network_name}: Invalid datatokenAddress. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
+                )
+        except Exception as e:
+                raise Exception(
+                    f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
+                )
 
-        if Web3.toChecksumAddress(files_json["nftAddress"]) != Web3.toChecksumAddress(
-            asset.nftAddress
-        ):
+        try:
+            if Web3.toChecksumAddress(files_json["nftAddress"]) != Web3.toChecksumAddress(
+                asset.nftAddress
+            ):
+                raise Exception(
+                    f"Provider {network_name}: Invalid nftAddress. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
+                )
+        except:
             raise Exception(
-                f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
-            )
-
+                    f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
+                )
         files_list = files_json["files"]
         if not isinstance(files_list, list):
             raise TypeError(

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -60,11 +60,11 @@ def get_service_files_list(
                 files_json["datatokenAddress"]
             ) != Web3.toChecksumAddress(service.datatoken_address):
                 raise Exception(
-                    f"Provider {network_name}: Invalid datatokenAddress. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
+                    f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
                 )
         except Exception as e:
             raise Exception(
-                f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
+                f"Provider {network_name}: Invalid datatokenAddress. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
             )
 
         try:
@@ -72,11 +72,11 @@ def get_service_files_list(
                 files_json["nftAddress"]
             ) != Web3.toChecksumAddress(asset.nftAddress):
                 raise Exception(
-                    f"Provider {network_name}: Invalid nftAddress. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
+                    f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
                 )
         except:
             raise Exception(
-                f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
+                f"Provider {network_name}: Invalid nftAddress. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
             )
         files_list = files_json["files"]
         if not isinstance(files_list, list):

--- a/ocean_provider/utils/util.py
+++ b/ocean_provider/utils/util.py
@@ -63,21 +63,21 @@ def get_service_files_list(
                     f"Provider {network_name}: Invalid datatokenAddress. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
                 )
         except Exception as e:
-                raise Exception(
-                    f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
-                )
+            raise Exception(
+                f"Provider {network_name}: Mismatch of datatoken. Got {files_json['datatokenAddress']} vs expected {service.datatoken_address}"
+            )
 
         try:
-            if Web3.toChecksumAddress(files_json["nftAddress"]) != Web3.toChecksumAddress(
-                asset.nftAddress
-            ):
+            if Web3.toChecksumAddress(
+                files_json["nftAddress"]
+            ) != Web3.toChecksumAddress(asset.nftAddress):
                 raise Exception(
                     f"Provider {network_name}: Invalid nftAddress. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
                 )
         except:
             raise Exception(
-                    f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
-                )
+                f"Provider {network_name}: Mismatch of dataNft. Got {files_json['nftAddress']} vs expected {asset.nftAddress}"
+            )
         files_list = files_json["files"]
         if not isinstance(files_list, list):
             raise TypeError(


### PR DESCRIPTION
If either datatokenAddress or nftAddress are malformed in the encrypted files string

(example:
```
b'{"datatokenAddress":"0x0","nftAddress":"0x0","files":[{"type":"url","url":"https://github.com/......0Safety%20Traffic%20Accident%20Analysis%2028eaf51fb56f4fbe80cb1ac0e552d384.pdf","method":"GET"}]}'
```


,provider fails with:

```
2024-02-07 05:59:01 provider-59c9fdb476-fl7pt ocean_provider.utils.util[12] ERROR Provider polygon: Error decrypting service files <class 'ocean_provider.utils.services.Service'>: Unknown format 0x0, attempted to normalize to 0x0
2024-02-07 05:59:01 provider-59c9fdb476-fl7pt ocean_provider.routes.consume[18] ERROR Provider polygon: Unable to get dataset files
```

Why?  cause this is where it fails:   https://github.com/oceanprotocol/provider/blob/main/ocean_provider/utils/util.py#L58
Because Web3.toChecksumAddress complains about unknown format "0x0".. 

Obviously, this will fail the validation, but it will give you a clue why it failed
This PR adds more detailed logs



PS: This also updates .github/workflows/pytest.yml